### PR TITLE
qbraid + qiskit updates for first quantum program

### DIFF
--- a/First_quantum_program.ipynb
+++ b/First_quantum_program.ipynb
@@ -19,6 +19,63 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/jovyan/.qbraid/environments/qbraid_sdk_9j9sjy/pyenv/lib/python3.9/site-packages/networkx/utils/backends.py:135: RuntimeWarning: networkx backend defined more than once: nx-loopback\n",
+      "  backends.update(_get_backends(\"networkx.backends\"))\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "qBraid: A Python toolkit for cross-framework abstraction of quantum programs\n",
+      "==============================================================================\n",
+      "Authored by: qBraid Development Team (https://github.com/qBraid/qBraid)\n",
+      "\n",
+      "qbraid:\t0.7.0.dev\n",
+      "\n",
+      "Core Dependencies\n",
+      "-----------------\n",
+      "qbraid_core: 0.1.4\n",
+      "networkx: 3.2.1\n",
+      "openqasm3: 0.5.0\n",
+      "numpy: 1.26.4\n",
+      "ply: 3.11\n",
+      "\n",
+      "Optional Dependencies\n",
+      "---------------------\n",
+      "pyquil: 4.4.0\n",
+      "qiskit: 1.0.2\n",
+      "braket: 1.74.1\n",
+      "pennylane: 0.35.1\n",
+      "cirq: 1.3.0\n",
+      "pytket: 1.23.0\n",
+      "qiskit_ibm_provider: 0.10.0\n",
+      "qiskit_ibm_runtime: 0.20.0\n",
+      "qbraid_qir: 0.2.0.dev\n",
+      "\n",
+      "Python: 3.9.18\n",
+      "Platform: Linux (x86_64)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import qbraid\n",
+    "\n",
+    "qbraid.about()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -34,7 +91,7 @@
     "- At the very top of the right sidebar, click on the \"ENVS\" icon;\n",
     "- In the window that opens, click on \"ADD\" at the top right;\n",
     "- Look for qBraid-SDK in the list of environments. Click on the dropdown arrow on qBraid-SDK, and then on \"install\". This will install the environment in your virtual workspace. You can track the progress of the installation, by clicking on \"Browse Environments\" at the top, which will take you back to the page \"My Environments\". *If you don't see qBraid-SDK, this means that it is already installed! Once you are back in the \"My Environments\", qBraid-SDK should already be there.\n",
-    "- Once the installation is complete, click on \"Activate\" (the environemnt may already be automatically actived for you)."
+    "- Once the installation is complete, click on \"Add kernel\" (the environemnt may already be automatically actived for you)."
    ]
   },
   {
@@ -50,7 +107,7 @@
    "source": [
     "Each Jupyter notebook uses a \"kernel\", i.e. a backend, to run code that appears in the notebook. We want to switch to a kernel where all of the necessary packages to run on quantum devices are already installed.\n",
     "\n",
-    "Once you have completed the steps above, open the Jupyter notebook on which you plan to run your code on quantum devices. At the top right of the Jupyter notebook, click where it says \"Python [Default].\" (this is most likely what you will see unless you have already switched to a different kernel). A dropdown menu will appear (where Python 3[Default] is one of the options). You should now also see the option Python 3[qBraid-SDK]. Select this."
+    "Once you have completed the steps above, open the Jupyter notebook on which you plan to run your code on quantum devices. At the top right of the Jupyter notebook, click where it says `Python [Default]`. (this is most likely what you will see unless you have already switched to a different kernel). A dropdown menu will appear (where `Python 3 [Default]` is one of the options). You should now also see the option `Python 3 qBraid]`. Select this."
    ]
   },
   {
@@ -82,25 +139,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAKIAAACuCAYAAAC1MNZgAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAAH/ElEQVR4nO3dX2xT5x3G8cdOaJxgGwSkc52/MGMVJySRiJhyMUEYfxdFgW2KpiLUSonUGwZSEe4NVwVBw7hi7IIOXxQ0sfQiQxpBnYSIS4boFAhhKIkaQRVKYh8qjyjhOCGR7bOLjqqA2yaO7fPz2+dzGR+f81P01Xte27FiMQzDAJHJrGYPQAQwRBKCIZIIDJFEYIgkAkMkERgiicAQSQSGSCIwRBKBIZIIDJFEYIgkAkMkERgiicAQSQSGSCIwRBKBIZIIDJFEYIgkAkMkERgiicAQSQSGSCIwRBKBIZIIDJFEYIgkAkMkERgiicAQSQSGSCIwRBKBIZIIDJFEYIgkQr7ZA6jMMAxgdtbsMRamoAAWiyXrl2WImTQ7i1jr22ZPsSD5n3wM2GxZvy5vzSQCQyQRGCKJwBBJBIZIIjBEEoEhkggMkURgiCQCQyQRGCKJwBBJBIZIIigXYiQSgd/vh8fjgc1mQ1lZGQ4ePIhoNIq2tjZYLBacOXPG7DHpJUr9GdjAwAB27doFTdOwdOlS+Hw+hEIhnD59Gg8ePMCTJ08AAHV1deYOukCfRb7GtptBfOirwXs/fzPpMa/94xP8+vU3cOkXv8zydOmhzIoYiUTQ3NwMTdNw6NAhhMNh9Pf3Q9M0dHR0oLu7G319fbBYLKipqTF7XHqJMiEeOHAAY2Nj2L9/P06dOgWHw/HtY36/H7W1tYjFYqisrITT6TRxUkpGiRCHh4fR2dmJVatW4cSJE0mP2bBhAwCgtrY2m6PRPCmxR7x48SISiQT27t0Lu92e9JjCwkIAuR3idDyOSK59B2aelAjx2rVrAIDGxsbvPWZsbAxAbof4wReD+OCLQbPHyAglQnz48CEAoKKiIunjsVgMN27cALC4EOvr66Fp2ryPL7RaMVTXkPL1XtZevga/dZclfWzX55+l5RperxcziURKz3W5XLh161ZKz1UixGg0CgCYmZlJ+nhnZycikQgcDgdWr16d8nU0TcP4+Pi8jy/KywPqUr7cKzx2O35V/LP0nTCJUCiE6Xg8o9dIRokQXS4XJiYm0N/fj4aGF1egcDiMw4cPAwBqamoW9Z1dl8u1oOMLrbn3WtDtdi9qRUyVEiFu3boVw8PD6OjowLZt2+D1egEAfX192LdvHyKRCIDFv5G90NuO8exZzn2veWRkBBZ+rzk1fr8fK1euxKNHj1BVVYX169dj7dq12LhxI9asWYMtW7YAyO0XKqpTIsTS0lL09vaiqakJNpsNo6OjWLFiBc6ePYvu7m6MjIwAYIiSKXFrBoB169bh8uXLr/xc13WMjo7CarWiurrahMloPpQJ8fsMDg7CMAx4vV4UFRWZPU5KNq16HXPNrT94zI89Lp0St+Yfcu/ePQC8LUvHEEkEhkgiKL9HfP45NMmm/IpIuYEhkggMkURgiCQCQyQRGCKJwBBJBIZIIjBEEoEhkggMkUSwGIZhmD2EqvhPIeePIZIIvDWTCAyRRGCIJAJDJBEYIonAEEkEhkgiMEQSgSGSCAyRRGCIJAJDJBEYIonAEEkEhkgiMEQSgSGSCAyRRGCIJAJDJBEYIonAENPs+vXraGlpQUVFBSwWC44dO2b2SDmBIaaZruvw+Xw4efLkov5J4k8Nv9ecQZWVlWhvb8eRI0fMHkU8rogkAkMkERgiicAQSQSGSCIo/y/Qsk3Xddy/fx8AMDc3B03TMDAwALvdDo/HY/J0cvHtmzQLBoNobGx85eebNm1CMBjM/kA5giGSCNwjmuTLr0KIxeJmjyEGQzTBxORTBDqv4I8f/Q369IzZ44igZIjxeBwXLlzA9u3bUVxcjIKCApSXl2Pnzp04d+4c4nFzV6Lg5wOIJxIoXrEc9qJCU2eRQrk94tTUFHbv3o2enh4AgNvtRklJCUKhEEKhEAzDwMTEBJYvX27KfBOTT3Hqo07EEwm8+1YzVpe9Ycoc0ij39k1bWxt6enpQWlqK8+fPv/AK9vHjxwgEAliyZIlp8z1fDT0VJYzwO5RaEW/fvo36+nrk5+fjzp07qK6uTuv5//RxF57qqe/pEkYCevSb5y8ttCEvLy9do4ngsBfiD2//JqXnKrUiXrp0CQDQ1NSU9ggB4Kk+gyk9mpZzRWeepeU8qlAqxKGhIQBAQ0NDRs7vsKf+wkL11RBY3O9HqRCnpqYAAMuWLcvI+VO97QDA3//Zi38PDMNTUYL23zelcSo1KBWi0+kEAExOTmbk/KnuEb+7Goa//i+O//mv6R5NBO4R/6+qqgpdXV24efNmRs6fjj0i94bJKRXinj17cPToUVy5cgVDQ0Pw+XxpPX8qe6Cfwt7wucXsEWEoprW11QBglJeXG8Fg8IXHNE0zjh8/bui6nrV5uj69brz/4VnjLxcvZ+2auUip9xGBb16wtLS0fPsnVyUlJXC73QiHwxgfH8/qJyv8FGX+lPus2el04urVqwgEAti8eTOmp6dx9+5dWK1W7NixA4FAAA6HIyuz8FOU+VNuRZTk6r9uo7fvP3jndzsZ4o9giBn2bHYOtoLXzB5DPIZIIii3R6TcxBBJBIZIIjBEEoEhkggMkURgiCQCQyQRGCKJwBBJBIZIIjBEEoEhkggMkURgiCQCQyQRGCKJwBBJBIZIIjBEEoEhkggMkURgiCQCQyQRGCKJwBBJBIZIIjBEEoEhkggMkURgiCQCQyQRGCKJwBBJBIZIIjBEEoEhkggMkURgiCTC/wDp+qugJAth5QAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 185.453x200.667 with 1 Axes>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# qiskit contains the class QuantumCircuit with which you can build quantum circuits.\n",
     "# So, the first step is to import this class\n",
     "from qiskit import QuantumCircuit\n",
     "\n",
     "# The QuantumCircuit class is initialized by specifying the number of qubits in the circuit.\n",
-    "# When we measure the quantum circuit later, we will need a classical bit to store the output \n",
-    "#from each qubit.\n",
-    "circ = QuantumCircuit(1,1)\n",
-    "# The first argument '1' to QuantumCircuit specifies that we will be using just 1 qubit. \n",
-    "# The second argument '1' specifies that we will be storing a single classical bit \n",
+    "# When we measure the quantum circuit later, we will need a classical bit to store the output\n",
+    "# from each qubit.\n",
+    "circ = QuantumCircuit(1, 1)\n",
+    "# The first argument '1' to QuantumCircuit specifies that we will be using just 1 qubit.\n",
+    "# The second argument '1' specifies that we will be storing a single classical bit\n",
     "# of output from our future measurement, i.e. we will measure a single qubit.\n",
     "\n",
-    "#To add a Hadamard gate we use the function 'h' of QuantumCircuit:\n",
+    "# To add a Hadamard gate we use the function 'h' of QuantumCircuit:\n",
     "circ.h(0)\n",
     "\n",
     "# In the above line, circ is the circuit we just created, and we are inserting the hadamard gate using '.h(0)'\n",
@@ -108,7 +177,7 @@
     "# And yes, the qubit numbering starts at 0, as is typical in Python.\n",
     "\n",
     "# At this point we already have a quantum circuit ready. We can \"draw\" it by using the function 'draw'\n",
-    "circ.draw(output='mpl')"
+    "circ.draw(output=\"mpl\")"
    ]
   },
   {
@@ -127,27 +196,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'0': 520, '1': 480}\n"
+     ]
+    }
+   ],
    "source": [
-    "circ.measure(0,0)\n",
+    "circ.measure(0, 0)\n",
     "# The first argument specifies that we are measuring the first qubit (Python starts counting\n",
-    "# from zero), and the second argument specifies that we are storing the output \n",
+    "# from zero), and the second argument specifies that we are storing the output\n",
     "# of this measurement in the first output bit.\n",
     "\n",
     "# Import Aer and execute\n",
-    "from qiskit import Aer, execute\n",
-    "# The Aer module contains many simulators. We will be using one called qasm_simulator. \n",
+    "from qiskit_aer import AerSimulator\n",
+    "\n",
+    "# The Aer module contains many simulators. We will be using one called qasm_simulator.\n",
     "# By convention, we refer to the simulator (or the actual quantum computer) as a backend.\n",
     "# and if you wanted to run your quantum circuit on an actual quantum computer, you would just need to replace\n",
     "# 'qasm_simulator' with the name of the quantum computer.\n",
-    "backend_sim = Aer.get_backend('qasm_simulator')\n",
+    "backend_sim = AerSimulator()\n",
     "\n",
     "# Once you specify the backend, you can just go ahead and execute the circuit with the function execute.\n",
-    "sim = execute(circ, backend_sim, shots=1000)\n",
+    "sim = backend_sim.run(circ, shots=1000)\n",
     "# Shots specifies how many times the quantum circuit is run.\n",
     "\n",
     "# The results from the execution are stored in 'sim' and can be obtained using\n",
@@ -167,13 +245,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjsAAAGkCAYAAADXDuRQAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAA9C0lEQVR4nO3deXRU9f3/8de9k4WQMAkkZINsQFiigVBAkuJRUUpArKK4oBTQqrT8gBZptWq1Ftsj1VoXKpavPS2oFRfcBRQBD6ASIQSBAJqQkA1CEiCQSSIZwsz8/kiYSeoeAoO3z8c5cw7zvnfu53M/5N55zV1mDI/H4xEAAIBFmf7uAAAAwJlE2AEAAJZG2AEAAJZG2AEAAJZG2AEAAJZG2AEAAJZG2AEAAJZG2AEAAJZG2AEAAJZG2AEAAJbm97Bz4MAB/exnP1NkZKRCQkKUnp6urVu3eqd7PB794Q9/UFxcnEJCQjRmzBjt3bu33TJqa2s1ZcoU2e12RURE6NZbb1VDQ8PZXhUAAHAO8mvYOXr0qEaNGqXAwEC9++672rNnj/72t7+pe/fu3nkeeeQRLVy4UIsXL9bmzZsVGhqq7OxsNTU1eeeZMmWKdu/erTVr1mjFihXauHGjZsyY4Y9VAgAA5xjDnz8Eevfdd+vjjz/Whx9++JXTPR6P4uPj9Zvf/Ea//e1vJUl1dXWKiYnR0qVLNXnyZH322WdKS0tTbm6uhg8fLkl67733dPnll2v//v2Kj48/a+sDAADOPQH+bPztt99Wdna2rrvuOm3YsEG9evXS//t//0+33367JKmkpERVVVUaM2aM9zXh4eEaOXKkcnJyNHnyZOXk5CgiIsIbdCRpzJgxMk1Tmzdv1tVXX/2ldp1Op5xOp/e52+1WbW2tIiMjZRjGGVxjAADQWTwej+rr6xUfHy/T/PqTVX4NO/v27dM//vEPzZs3T/fee69yc3P1q1/9SkFBQZo+fbqqqqokSTExMe1eFxMT451WVVWl6OjodtMDAgLUo0cP7zz/bcGCBZo/f/4ZWCMAAHC2VVRUqHfv3l873a9hx+12a/jw4XrooYckSUOHDtWuXbu0ePFiTZ8+/Yy1e88992jevHne53V1dUpMTFRFRYXsdvsZaxcAAHQeh8OhhIQEdevW7Rvn82vYiYuLU1paWrvaoEGD9Nprr0mSYmNjJUnV1dWKi4vzzlNdXa2MjAzvPDU1Ne2WcfLkSdXW1npf/9+Cg4MVHBz8pbrdbifsAADwA/Ntl6D49W6sUaNGqaCgoF2tsLBQSUlJkqSUlBTFxsZq3bp13ukOh0ObN29WVlaWJCkrK0vHjh1TXl6ed54PPvhAbrdbI0eOPAtrAQAAzmV+PbJzxx136Mc//rEeeughXX/99dqyZYueeeYZPfPMM5JaktrcuXP15z//WampqUpJSdH999+v+Ph4TZw4UVLLkaBx48bp9ttv1+LFi9Xc3KzZs2dr8uTJ3IkFAAD8e+u5JK1YsUL33HOP9u7dq5SUFM2bN897N5bUcqX1Aw88oGeeeUbHjh3ThRdeqKefflr9+/f3zlNbW6vZs2frnXfekWmamjRpkhYuXKiwsLDv1AeHw6Hw8HDV1dVxGgsAgB+I7/r+7fewcy4g7AAA8MPzXd+//f5zEQAAAGcSYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQcAAFgaYQeWkpycrAEDBigjI0MZGRl6+eWX1dTUpIkTJ6p///4aMmSIfvKTn6ioqMj7mpqaGo0bN06pqak6//zztXHjRj+uAQCgswX4uwNAZ3v55ZeVkZHhfd7U1KQZM2Zo/PjxMgxDTz31lG677TatX79eknT33XcrMzNT7733nnJzc3X11VerpKREgYGB/lkBAECn4sgOLK9Lly66/PLLZRiGJCkzM1OlpaXe6a+88op++ctfSpJGjBih+Ph4bdiwwR9dBQCcAYQdWM60adOUnp6uW2+9VYcOHfrS9CeffFJXXXWVJOnIkSNqbm5WbGysd3pycrLKy8vPWn8BAGcWYQeWsnHjRu3cuVPbtm1TVFSUpk+f3m76Qw89pKKiIi1YsMBPPQQAnG1cswNLSUxMlCQFBgZq7ty56t+/v3fao48+qtdff11r165V165dJUmRkZEKCAhQVVWV9+hOaWmpdzkAgB8+juzAMhobG3Xs2DHv8xdffFFDhw6VJD322GN68cUXtWbNGkVERLR73XXXXafFixdLknJzc3XgwAFdfPHFZ6vbAIAzzPB4PB5/d8LfHA6HwsPDVVdXJ7vd7u/uoIP27dunSZMmyeVyyePxqE+fPnryyScVEBCghIQE9enTR926dZMkBQcHa/PmzZKk6upqTZ06VSUlJQoKCtJTTz2l0aNH+3NVAADfwXd9/ybsiLADAMAP0Xd9/+Y0FgAAsDTCDgAAsDTCDgAAsDTCDgAAsDTCDgAAsDTCDgAAsDTCDgAAsDR+LuIMS757pb+7AJzTSv8ywd9dAGBxHNkBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACW5tew88c//lGGYbR7DBw40Du9qalJs2bNUmRkpMLCwjRp0iRVV1e3W0Z5ebkmTJigrl27Kjo6WnfeeadOnjx5tlcFAHCWLVmyRIZh6M0335QkbdmyRZmZmRo6dKgGDRqkRx55xDvvF198oRtvvFH9+vVT//799eqrr/qp1/AHv3+D8nnnnae1a9d6nwcE+Lp0xx13aOXKlVq+fLnCw8M1e/ZsXXPNNfr4448lSS6XSxMmTFBsbKw2bdqkgwcPatq0aQoMDNRDDz101tcFAHB2lJaW6p///KcyMzO9tRkzZujBBx/UlVdeqdraWg0cOFBXXHGF0tLS9Oijjyo4OFhFRUUqKSnRyJEjNXr0aEVGRvpxLXC2+P00VkBAgGJjY72PqKgoSVJdXZ3+9a9/6bHHHtOll16qYcOGacmSJdq0aZM++eQTSdL777+vPXv26D//+Y8yMjI0fvx4/elPf9KiRYt04sSJr23T6XTK4XC0ewAAfhjcbrduu+02/f3vf1dwcLC3bhiGjh07JklqbGxUUFCQevToIUl6+eWX9ctf/lKSlJKSoksuuURvvPHGWe87/MPvR3b27t2r+Ph4denSRVlZWVqwYIESExOVl5en5uZmjRkzxjvvwIEDlZiYqJycHGVmZionJ0fp6emKiYnxzpOdna2ZM2dq9+7dGjp06Fe2uWDBAs2fP/9L9a1btyosLEySlJGRofr6ehUXF7dr32azaffu3d5acnKyIiMjlZeX563FxMQoKSlJ27dv18/7uyRJ+xsNvX/A1LjeLsV3bZmvvllaXmJTVrRbgyI83tcvKTQ1KMKjzGhf7fVSU6EBUnZvt7e2rtLUkSbp+j6+Wt5hQztqTd2c6pJptI6xw9CHVaauTnKpe+t+oaZJWlFu06XxbiWHtbTjdEsvFNk0LMqtIT18bS8rNtUrVLo41tfOygpTbo/000Rf7aNqQyX1hqb289XyjxrKPWTqxr4uhdhaauUNhtZWmro8waXYkJZaXbP0WolNo2LcGhDua/vfhTad392tC3r6aq+VmuoWKI3t5Wtn7QFTx05I16b4armHDOUfNXVLf5dah0KFdYY+qjZ1TbJLEUEtterj0soKmy6LdyupdSyaXNKyYpuGR7k1uM1YvFBkKiHMo4tifbUV5S2fGa5oMxYbqwxVNBia0mYsdtYa2nrY1E19XerSOhZlDYbWVZqakOBSTOtYHDshvV5q04UxbvVvHQuPpCWFNqV3d2tEm7F4tcRURJA0ps1YvH/AVH2zNCnZV9tyyNCuo6b371GSCuoMfVxtalKKS+GBLbWq49KqCpvGxLuV2DoWx13Si8U2jejpVnp3X9vPF5lK6ebRhTG+2jvlpkxDmpDga3tDlakDjdJNfX21HbWG8g6bmtLPpS1btkiSunfvrtTUVO3Zs0cNDQ2SpJCQEKWnp2vfvn06fPiwpJY3tBEjRqiyslL79+/3LnPIkCFqbGxUUVGRtzZgwAAFBQUpPz/fW0tMTFRMTIxyc3O9tejoaCUnJ2vHjh1yOp2SJLvdroEDB6qgoEB1dXWSpKCgIGVkZKisrKzdKfVhw4bpyJEjKi0t9dbOO+88uVwuff75595a37591a1bN23fvt1b69Wrl3r16qW8vDy5XC3/Pz169FC/fv20e/duNTY2SpK6du2q888/X8XFxTpy5IgkyTRNDR8+XAcOHNCBAwe+dSwCAwO1a9cuby0pKUk9e/bU1q1bvbVT+6+2YxEeHq4BAwa0G4vg4GANGTLkS2MxfPhwHTp0SGVlZd7a+eefr+bmZhUUFHhr/fr1U2hoqHbs2PGlsdi6davc7pa/l8jISPXt21e7du3SF198IUl65ZVXNGrUKIWHh6u+vl579+5VXl6elixZoiuuuEJ33XWXjh07prvvvls9evTw/t/U1tZqy5YtGjhwoHr16qWcnBwNHjxY0rfvy099gD41Fp9//rn3g/KpsSgtLVVNTY339SNGjFB1dbXKy8u9tfT0dJ04ceJbx6J3796Kj49Xbm6uPJ6WbSwqKkp9+vRRfn6+jh8/LkkKCwtTWlqa9u7dq6NHj0qSbDabhg0bpv3796uystK7zKFDh6qurk779u3z1gYNGiTDMLRnzx5vLTk5WT169NC2bdu8tdjYWCUmJurTTz9Vc3OzJCkiIkL9+/fXZ599pvr6eklSly5dNHjwYJWUlOjQoUPe119wwQU6ePCgKioq2o2F0+lUYWGht5aamqqQkBDt3LnTW0tISFBcXJx3X9F2LNq+H38Tw3NqFP3g3XffVUNDgwYMGKCDBw9q/vz5OnDggHbt2qV33nlHt9xyi3djO+WCCy7Q6NGj9fDDD2vGjBkqKyvT6tWrvdO/+OILhYaGatWqVRo/fvxXtut0Otst1+FwKCEhQXV1dbLb7Z26jvwQKPDN+CFQfB+7du3S7bffro0bNyowMFCXXHKJ5s6dq4kTJ2ry5Mm68sorddNNN2nfvn26+OKLtXr1aqWlpalbt24qLCxUXFycJOmuu+5Sly5d9OCDD/p5jXA6HA6HwsPDv/X9269HdtqGkcGDB2vkyJFKSkrSK6+8opCQkDPWbnBwcLtDnwCAH4YPP/xQpaWlSk1NlSRVVVVpxowZys/P1xtvvKGXXnpJktSnTx9lZmbq448/VlpamhITE1VWVuYNO6WlpRo7dqzf1gNnl9+v2Wnr1CGxoqIixcbG6sSJE97zr6dUV1crNjZWUsthtf++O+vU81PzAACsY+bMmTp48KBKS0tVWlqqzMxMPfPMM7r33nsVGhqqDz74QJJ0+PBhbd68Weeff74k6brrrtPixYslSSUlJVq/fr0mTpzor9XAWXZOhZ2GhgYVFxcrLi5Ow4YNU2BgoNatW+edXlBQoPLycmVlZUmSsrKylJ+f3+4c6Zo1a2S325WWlnbW+w8A8A+bzaZXXnlFd955p4YMGaKLLrpIc+fO9b5f3HnnnTp+/Lj69u2r7OxsPfXUU94bYmB9fr1m57e//a1++tOfKikpSZWVlXrggQe0fft27dmzRz179tTMmTO1atUqLV26VHa7XXPmzJEkbdq0SVLLrecZGRmKj4/XI488oqqqKk2dOlW33Xbb97r1/Lue8+sIrtkBvhnX7ADoqB/ENTv79+/XjTfeqCNHjqhnz5668MIL9cknn6hnz56SpMcff1ymaWrSpElyOp3Kzs7W008/7X29zWbTihUrNHPmTGVlZSk0NFTTp0/ngjMAAODl1yM75wqO7AD+w5EdAB31Xd+/z6lrdgAAADobYQcAAFgaYQcAAFgaYQcAAFia338bCwCsgJsRgK/n7xsROLIDAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAs7ZwJO3/5y19kGIbmzp3rrTU1NWnWrFmKjIxUWFiYJk2apOrq6navKy8v14QJE9S1a1dFR0frzjvv1MmTJ89y7wEAwLnqnAg7ubm5+r//+z8NHjy4Xf2OO+7QO++8o+XLl2vDhg2qrKzUNddc453ucrk0YcIEnThxQps2bdKzzz6rpUuX6g9/+MPZXgUAAHCO8nvYaWho0JQpU/TPf/5T3bt399br6ur0r3/9S4899pguvfRSDRs2TEuWLNGmTZv0ySefSJLef/997dmzR//5z3+UkZGh8ePH609/+pMWLVqkEydO+GuVAADAOcTvYWfWrFmaMGGCxowZ066el5en5ubmdvWBAwcqMTFROTk5kqScnBylp6crJibGO092drYcDod27979tW06nU45HI52DwAAYE0B/mz8pZde0rZt25Sbm/ulaVVVVQoKClJERES7ekxMjKqqqrzztA06p6afmvZ1FixYoPnz53+pvnXrVoWFhUmSMjIyVF9fr+LiYu/0gQMHymaztQtSycnJioyMVF5eXrs+JCUlafv27fp5f5ckaX+jofcPmBrX26X4ri3z1TdLy0tsyop2a1CEx/v6JYWmBkV4lBntq71eaio0QMru7fbW1lWaOtIkXd/HV8s7bGhHrambU10yjZbaXoehD6tMXZ3kUvfgllpNk7Si3KZL491KDmtpx+mWXiiyaViUW0N6+NpeVmyqV6h0cayvnZUVptwe6aeJvtpH1YZK6g1N7eer5R81lHvI1I19XQqxtdTKGwytrTR1eYJLsSEttbpm6bUSm0bFuDUg3Nf2vwttOr+7Wxf09NVeKzXVLVAa28vXztoDpo6dkK5N8dVyDxnKP2rqlv4utQ6FCusMfVRt6ppklyKCWmrVx6WVFTZdFu9WUutYNLmkZcU2DY9ya3CbsXihyFRCmEcXxfpqK8pbPjNc0WYsNlYZqmgwNKXNWOysNbT1sKmb+rrUpXUsyhoMras0NSHBpZjWsTh2Qnq91KYLY9zq3zoWHklLCm1K7+7WiDZj8WqJqYggaUybsXj/gKn6ZmlSsq+25ZChXUdN79+jJBXUGfq42tSkFJfCA1tqVcelVRU2jYl3K7F1LI67pBeLbRrR06307r62ny8yldLNowtjfLV3yk2ZhjQhwdf2hipTBxqlm/r6ajtqDeUdNjWln0tbtmyRJHXv3l2pqanas2ePGhoaJEkhISFKT0/Xvn37dPjwYUmSYRgaMWKEKisrtX//fu8yhwwZosbGRhUVFXlrAwYMUFBQkPLz8721xMRExcTEtNvvREdHKzk5WTt27JDT6ZQk2e12DRw4UAUFBaqrq5MkBQUFKSMjQ2VlZe2uHxw2bJgGhLs1qs1YvFVmKsiUxrcZi/UHTVUdlya32WY/PWLo0yOmpvZzKbD14+e+ekPrD5q6MtGlqC4ttSNO6a0ymy6OdauvvaWdkx7pub02ZfRw60dRvrZf3meqZxfp0nhfO+/tN9XkkiYm+Wo5NYYK6gzdnOqr7Tlm6JMaU9enuBTW+ndx4AtDq/ebyu7tVq+uLe00NEuvlNiUGe1WWpv919K9pgaEe5TVZv/1ZpmpLjZpXJv91weVpg41STe0GYtthw1trzU1LdWlgNaNtthhaEOVqauSXIps3X8dbpLeLrfpkji3+nRraafZLT1fZNPQSLeGRvrafmmfqdgQ6ZI4XzvvVpg64ZauajMWH1cbKnYYmtZmLHYfNbT5kKkb+rgU2vpuyb68Y/tySTp48KAqKiq8z9PT0+V0OlVYWOitpaamKiQkRDt37vTWEhISFBcX591XSFJUVJT69OnzjQc22jI8Ho/n22frfBUVFRo+fLjWrFnjvVbnkksuUUZGhp544gktW7ZMt9xyi3fHc8oFF1yg0aNH6+GHH9aMGTNUVlam1atXe6d/8cUXCg0N1apVqzR+/PivbNvpdLZbrsPhUEJCgurq6mS32zt1PZPvXtmpywOspvQvE/zdhU7Btg58vTO1nTscDoWHh3/r+7ffTmPl5eWppqZGP/rRjxQQEKCAgABt2LBBCxcuVEBAgGJiYnTixAkdO3as3euqq6sVGxsrSYqNjf3S3Vmnnp+a56sEBwfLbre3ewAAAGvyW9i57LLLlJ+fr+3bt3sfw4cP15QpU7z/DgwM1Lp167yvKSgoUHl5ubKysiRJWVlZys/PV01NjXeeNWvWyG63Ky0t7ayvEwAAOPf47Zqdbt266fzzz29XCw0NVWRkpLd+6623at68eerRo4fsdrvmzJmjrKwsZWZmSpLGjh2rtLQ0TZ06VY888oiqqqp03333adasWQoODj7r6wQAAM49fr1A+ds8/vjjMk1TkyZNktPpVHZ2tp5++mnvdJvNphUrVmjmzJnKyspSaGiopk+frgcffNCPvQYAAOeScyrsrF+/vt3zLl26aNGiRVq0aNHXviYpKUmrVq06wz0DAAA/VH7/nh0AAIAzibADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsrUNhZ9u2bcrPz/c+f+uttzRx4kTde++9OnHiRKd1DgAA4HR1KOz84he/UGFhoSRp3759mjx5srp27arly5frrrvu6tQOAgAAnI4OhZ3CwkJlZGRIkpYvX66LLrpIy5Yt09KlS/Xaa691Zv8AAABOS4fCjsfjkdvtliStXbtWl19+uSQpISFBhw8f7rzeAQAAnKYOhZ3hw4frz3/+s55//nlt2LBBEyZMkCSVlJQoJiamUzsIAABwOjoUdh5//HFt27ZNs2fP1u9//3v169dPkvTqq6/qxz/+cad2EAAA4HQEdORFQ4YMaXc31il//etfFRDQoUUCAACcER06stOnTx8dOXLkS/Wmpib179//tDsFAADQWToUdkpLS+Vyub5Udzqd2r9//2l3CgAAoLN8r3NOb7/9tvffq1evVnh4uPe5y+XSunXrlJKS0nm9AwAAOE3fK+xMnDhRkmQYhqZPn95uWmBgoJKTk/W3v/2t0zoHAABwur5X2Dn13TopKSnKzc1VVFTUGekUAABAZ+nQrVMlJSWd3Q8AAIAzosP3ia9bt07r1q1TTU2N94jPKf/+979Pu2MAAACdoUNhZ/78+XrwwQc1fPhwxcXFyTCMzu4XAABAp+hQ2Fm8eLGWLl2qqVOndnZ/AAAAOlWHvmfnxIkT/CwEAAD4QehQ2Lntttu0bNmyzu4LAABAp+tQ2GlqatJjjz2miy++WHPmzNG8efPaPb6rf/zjHxo8eLDsdrvsdruysrL07rvvtmtn1qxZioyMVFhYmCZNmqTq6up2yygvL9eECRPUtWtXRUdH684779TJkyc7sloAAMCCOnTNzs6dO5WRkSFJ2rVrV7tp3+di5d69e+svf/mLUlNT5fF49Oyzz+qqq67Sp59+qvPOO0933HGHVq5cqeXLlys8PFyzZ8/WNddco48//lhSy7c2T5gwQbGxsdq0aZMOHjyoadOmKTAwUA899FBHVg0AAFiM4fF4PP7uRFs9evTQX//6V1177bXq2bOnli1bpmuvvVaS9Pnnn2vQoEHKyclRZmam3n33XV1xxRWqrKxUTEyMpJaLp3/3u9/p0KFDCgoK+so2nE6nnE6n97nD4VBCQoLq6upkt9s7dX2S717ZqcsDrKb0LxP83YVOwbYOfL0ztZ07HA6Fh4d/6/t3h79np7O5XC4tX75cjY2NysrKUl5enpqbmzVmzBjvPAMHDlRiYqI37OTk5Cg9Pd0bdCQpOztbM2fO1O7duzV06NCvbGvBggWaP3/+l+pbt25VWFiYJCkjI0P19fUqLi5u177NZtPu3bu9teTkZEVGRiovL89bi4mJUVJSkrZv366f92/5wdT9jYbeP2BqXG+X4ru2zFffLC0vsSkr2q1BEb7MuaTQ1KAIjzKjfbXXS02FBkjZvX3fabSu0tSRJun6Pr5a3mFDO2pN3Zzqktl6kG2vw9CHVaauTnKpe3BLraZJWlFu06XxbiWHtbTjdEsvFNk0LMqtIT18bS8rNtUrVLo41tfOygpTbo/000Rf7aNqQyX1hqb289XyjxrKPWTqxr4uhdhaauUNhtZWmro8waXYkJZaXbP0WolNo2LcGhDua/vfhTad392tC3r6aq+VmuoWKI3t5Wtn7QFTx05I16b4armHDOUfNXVLf5dOHW8srDP0UbWpa5JdimjNwtXHpZUVNl0W71ZS61g0uaRlxTYNj3JrcJuxeKHIVEKYRxfF+morylvOBl/RZiw2VhmqaDA0pc1Y7Kw1tPWwqZv6utSldSzKGgytqzQ1IcGlmNaxOHZCer3Upgtj3OrfOhYeSUsKbUrv7taINmPxaompiCBpTJuxeP+AqfpmaVKyr7blkKFdR03v36MkFdQZ+rja1KQUl8IDW2pVx6VVFTaNiXcrsXUsjrukF4ttGtHTrfTuvrafLzKV0s2jC2N8tXfKTZmGNCHB1/aGKlMHGqWb+vpqO2oN5R02NaWfS1u2bJEkde/eXampqdqzZ48aGhokSSEhIUpPT9e+fft0+PBhSS1Hj0eMGKHKysp2Pzw8ZMgQNTY2qqioyFsbMGCAgoKClJ+f760lJiYqJiZGubm53lp0dLSSk5O1Y8cO7wchu92ugQMHqqCgQHV1dZKkoKAgZWRkqKysrN0p9WHDhmlAuFuj2ozFW2WmgkxpfJuxWH/QVNVxaXKbbfbTI4Y+PWJqaj+XAlsvLNhXb2j9QVNXJroU1aWldsQpvVVm08WxbvW1t7Rz0iM9t9emjB5u/SjK1/bL+0z17CJdGu9r5739pppc0sQkXy2nxlBBnaGbU321PccMfVJj6voUl8Ja/y4OfGFo9X5T2b3d6tW1pZ2GZumVEpsyo91Ka7P/WrrX1IBwj7La7L/eLDPVxSaNa7P/+qDS1KEm6YY2Y7HtsKHttaampboU0LrRFjsMbagydVWSS5Gt+6/DTdLb5TZdEudWn24t7TS7peeLbBoa6dbQSF/bL+0zFRsiXRLna+fdClMn3NJVbcbi42pDxQ5D09qMxe6jhjYfMnVDH5dCW98t2Zd3bF8uSQcPHlRFRYX3eXp6upxOpwoLC7211NRUhYSEaOfOnd5aQkKC4uLivPsKSYqKilKfPn3avR9/kw4d2Rk9evQ3nq764IMPvvOy8vPzlZWVpaamJoWFhWnZsmW6/PLLtWzZMt1yyy3tjsBI0gUXXKDRo0fr4Ycf1owZM1RWVqbVq1d7p3/xxRcKDQ3VqlWrNH78+K9skyM7wLmDIzuA9f0gj+ycul7nlObmZm3fvl27du360g+EfpsBAwZo+/btqqur06uvvqrp06drw4YNHenWdxYcHKzg4OAz2gYAADg3dCjsPP74419Z/+Mf/+g9/PxdBQUFqV+/fpJaDgXn5ubqySef1A033KATJ07o2LFjioiI8M5fXV2t2NhYSVJsbGy7w1qnpp+aBgAA0KFbz7/Oz372s9P+XSy32y2n06lhw4YpMDBQ69at804rKChQeXm5srKyJElZWVnKz89XTU2Nd541a9bIbrcrLS3ttPoBAACsoVMvUM7JyVGXLl2+8/z33HOPxo8fr8TERNXX12vZsmVav369Vq9erfDwcN16662aN2+eevToIbvdrjlz5igrK0uZmZmSpLFjxyotLU1Tp07VI488oqqqKt13332aNWsWp6kAAICkDoada665pt1zj8ejgwcPauvWrbr//vu/83Jqamo0bdo0HTx4UOHh4Ro8eLBWr16tn/zkJ5JaTpeZpqlJkybJ6XQqOztbTz/9tPf1NptNK1as0MyZM5WVlaXQ0FBNnz5dDz74YEdWCwAAWFCH7sa65ZZb2j03TVM9e/bUpZdeqrFjx3Za586W73o1d0dwhwbwzbgbC7C+H+TdWEuWLOlwxwAAAM6m07pmJy8vT5999pkk6bzzzvvaL/EDAADwlw6FnZqaGk2ePFnr16/33hZ+7NgxjR49Wi+99JJ69uzZmX0EAADosA7dej5nzhzV19dr9+7dqq2tVW1trXbt2iWHw6Ff/epXnd1HAACADuvQkZ333ntPa9eu1aBBg7y1tLQ0LVq06Ad5gTIAALCuDh3ZcbvdCgwM/FI9MDBQbrf7K14BAADgHx0KO5deeql+/etfq7Ky0ls7cOCA7rjjDl122WWd1jkAAIDT1aGw89RTT8nhcCg5OVl9+/ZV3759lZKSIofDob///e+d3UcAAIAO69A1OwkJCdq2bZvWrl2rzz//XJI0aNAgjRkzplM7BwAAcLq+15GdDz74QGlpaXI4HDIMQz/5yU80Z84czZkzRyNGjNB5552nDz/88Ez1FQAA4Hv7XmHniSee0O233/6VX8kcHh6uX/ziF3rsscc6rXMAAACn63uFnR07dmjcuHFfO33s2LHKy8s77U4BAAB0lu8Vdqqrq7/ylvNTAgICdOjQodPuFAAAQGf5XmGnV69e2rVr19dO37lzp+Li4k67UwAAAJ3le4Wdyy+/XPfff7+ampq+NO348eN64IEHdMUVV3Ra5wAAAE7X97r1/L777tPrr7+u/v37a/bs2RowYIAk6fPPP9eiRYvkcrn0+9///ox0FAAAoCO+V9iJiYnRpk2bNHPmTN1zzz3yeDySJMMwlJ2drUWLFikmJuaMdBQAAKAjvveXCiYlJWnVqlU6evSoioqK5PF4lJqaqu7du5+J/gEAAJyWDn2DsiR1795dI0aM6My+AAAAdLoO/TYWAADADwVhBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWBphBwAAWJpfw86CBQs0YsQIdevWTdHR0Zo4caIKCgrazdPU1KRZs2YpMjJSYWFhmjRpkqqrq9vNU15ergkTJqhr166Kjo7WnXfeqZMnT57NVQEAAOcov4adDRs2aNasWfrkk0+0Zs0aNTc3a+zYsWpsbPTOc8cdd+idd97R8uXLtWHDBlVWVuqaa67xTne5XJowYYJOnDihTZs26dlnn9XSpUv1hz/8wR+rBAAAzjGGx+Px+LsTpxw6dEjR0dHasGGDLrroItXV1alnz55atmyZrr32WknS559/rkGDBiknJ0eZmZl69913dcUVV6iyslIxMTGSpMWLF+t3v/udDh06pKCgoG9t1+FwKDw8XHV1dbLb7Z26Tsl3r+zU5QFWU/qXCf7uQqdgWwe+3pnazr/r+/c5dc1OXV2dJKlHjx6SpLy8PDU3N2vMmDHeeQYOHKjExETl5ORIknJycpSenu4NOpKUnZ0th8Oh3bt3f2U7TqdTDoej3QMAAFhTgL87cIrb7dbcuXM1atQonX/++ZKkqqoqBQUFKSIiot28MTExqqqq8s7TNuicmn5q2ldZsGCB5s+f/6X61q1bFRYWJknKyMhQfX29iouLvdMHDhwom83WLkQlJycrMjJSeXl57dpPSkrS9u3b9fP+LknS/kZD7x8wNa63S/FdW+arb5aWl9iUFe3WoAjfAbYlhaYGRXiUGe2rvV5qKjRAyu7t9tbWVZo60iRd38dXyztsaEetqZtTXTKNltpeh6EPq0xdneRS9+CWWk2TtKLcpkvj3UoOa2nH6ZZeKLJpWJRbQ3r42l5WbKpXqHRxrK+dlRWm3B7pp4m+2kfVhkrqDU3t56vlHzWUe8jUjX1dCrG11MobDK2tNHV5gkuxIS21umbptRKbRsW4NSDc1/a/C206v7tbF/T01V4rNdUtUBrby9fO2gOmjp2Qrk3x1XIPGco/auqW/i61DoUK6wx9VG3qmmSXIloP+lUfl1ZW2HRZvFtJrWPR5JKWFds0PMqtwW3G4oUiUwlhHl0U66utKG/5zHBFm7HYWGWoosHQlDZjsbPW0NbDpm7q61KX1rEoazC0rtLUhASXYlrH4tgJ6fVSmy6Mcat/61h4JC0ptCm9u1sj2ozFqyWmIoKkMW3G4v0DpuqbpUnJvtqWQ4Z2HTW9f4+SVFBn6ONqU5NSXAoPbKlVHZdWVdg0Jt6txNaxOO6SXiy2aURPt9K7+9p+vshUSjePLozx1d4pN2Ua0oQEX9sbqkwdaJRu6uur7ag1lHfY1JR+Lm3ZskWS1L17d6WmpmrPnj1qaGiQJIWEhCg9PV379u3T4cOHJUmGYWjEiBGqrKzU/v37vcscMmSIGhsbVVRU5K0NGDBAQUFBys/P99YSExMVExOj3Nxcby06OlrJycnasWOHnE6nJMlut2vgwIEqKCjwfhALCgpSRkaGysrK2l07OGzYMA0Id2tUm7F4q8xUkCmNbzMW6w+aqjouTW6zzX56xNCnR0xN7edSYOvHz331htYfNHVloktRXVpqR5zSW2U2XRzrVl97SzsnPdJze23K6OHWj6J8bb+8z1TPLtKl8b523ttvqsklTUzy1XJqDBXUGbo51Vfbc8zQJzWmrk9xKaz17+LAF4ZW7zeV3dutXl1b2mloll4psSkz2q20NvuvpXtNDQj3KKvN/uvNMlNdbNK4NvuvDypNHWqSbmgzFtsOG9pea2paqksBrRttscPQhipTVyW5FNm6/zrcJL1dbtMlcW716dbSTrNber7IpqGRbg2N9LX90j5TsSHSJXG+dt6tMHXCLV3VZiw+rjZU7DA0rc1Y7D5qaPMhUzf0cSm09d2SfXnH9uWSdPDgQVVUVHifp6eny+l0qrCw0FtLTU1VSEiIdu7c6a0lJCQoLi7Ou6+QpKioKPXp0+drD2r8t3PmNNbMmTP17rvv6qOPPlLv3r0lScuWLdMtt9zi3fmccsEFF2j06NF6+OGHNWPGDJWVlWn16tXe6V988YVCQ0O1atUqjR8//kttOZ3Odst0OBxKSEjgNBbgB5zGAqzP36exzokjO7Nnz9aKFSu0ceNGb9CRpNjYWJ04cULHjh1rd3SnurpasbGx3nnapr1T009N+yrBwcEKDg7u5LUAAADnIr9es+PxeDR79my98cYb+uCDD5SSktJu+rBhwxQYGKh169Z5awUFBSovL1dWVpYkKSsrS/n5+aqpqfHOs2bNGtntdqWlpZ2dFQEAAOcsvx7ZmTVrlpYtW6a33npL3bp1815jEx4erpCQEIWHh+vWW2/VvHnz1KNHD9ntds2ZM0dZWVnKzMyUJI0dO1ZpaWmaOnWqHnnkEVVVVem+++7TrFmzOHoDAAD8G3b+8Y9/SJIuueSSdvUlS5bo5ptvliQ9/vjjMk1TkyZNktPpVHZ2tp5++mnvvDabTStWrNDMmTOVlZWl0NBQTZ8+XQ8++ODZWg0AAHAO82vY+S7XRnfp0kWLFi3SokWLvnaepKQkrVq1qjO7BgAALOKc+p4dAACAzkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlkbYAQAAlubXsLNx40b99Kc/VXx8vAzD0Jtvvtluusfj0R/+8AfFxcUpJCREY8aM0d69e9vNU1tbqylTpshutysiIkK33nqrGhoazuJaAACAc5lfw05jY6OGDBmiRYsWfeX0Rx55RAsXLtTixYu1efNmhYaGKjs7W01NTd55pkyZot27d2vNmjVasWKFNm7cqBkzZpytVQAAAOe4AH82Pn78eI0fP/4rp3k8Hj3xxBO67777dNVVV0mSnnvuOcXExOjNN9/U5MmT9dlnn+m9995Tbm6uhg8fLkn6+9//rssvv1yPPvqo4uPjz9q6AACAc9M5e81OSUmJqqqqNGbMGG8tPDxcI0eOVE5OjiQpJydHERER3qAjSWPGjJFpmtq8efPXLtvpdMrhcLR7AAAAa/LrkZ1vUlVVJUmKiYlpV4+JifFOq6qqUnR0dLvpAQEB6tGjh3eer7JgwQLNnz//S/WtW7cqLCxMkpSRkaH6+noVFxd7pw8cOFA2m027d+/21pKTkxUZGam8vLx2fUxKStL27dv18/4uSdL+RkPvHzA1rrdL8V1b5qtvlpaX2JQV7dagCI/39UsKTQ2K8Cgz2ld7vdRUaICU3dvtra2rNHWkSbq+j6+Wd9jQjlpTN6e6ZBottb0OQx9Wmbo6yaXuwS21miZpRblNl8a7lRzW0o7TLb1QZNOwKLeG9PC1vazYVK9Q6eJYXzsrK0y5PdJPE321j6oNldQbmtrPV8s/aij3kKkb+7oUYmuplTcYWltp6vIEl2JDWmp1zdJrJTaNinFrQLiv7X8X2nR+d7cu6OmrvVZqqlugNLaXr521B0wdOyFdm+Kr5R4ylH/U1C39XWodChXWGfqo2tQ1yS5FBLXUqo9LKytsuizeraTWsWhyScuKbRoe5dbgNmPxQpGphDCPLor11VaUt3xmuKLNWGysMlTRYGhKm7HYWWto62FTN/V1qUvrWJQ1GFpXaWpCgksxrWNx7IT0eqlNF8a41b91LDySlhTalN7drRFtxuLVElMRQdKYNmPx/gFT9c3SpGRfbcshQ7uOmt6/R0kqqDP0cbWpSSkuhQe21KqOS6sqbBoT71Zi61gcd0kvFts0oqdb6d19bT9fZCqlm0cXxvhq75SbMg1pQoKv7Q1Vpg40Sjf19dV21BrKO2xqSj+XtmzZIknq3r27UlNTtWfPHu91dyEhIUpPT9e+fft0+PBhSZJhGBoxYoQqKyu1f/9+7zKHDBmixsZGFRUVeWsDBgxQUFCQ8vPzvbXExETFxMQoNzfXW4uOjlZycrJ27Nghp9MpSbLb7Ro4cKAKCgpUV1cnSQoKClJGRobKyspUXV3tff2wYcM0INytUW3G4q0yU0GmNL7NWKw/aKrquDS5zTb76RFDnx4xNbWfS4GtHz/31Rtaf9DUlYkuRXVpqR1xSm+V2XRxrFt97S3tnPRIz+21KaOHWz+K8rX98j5TPbtIl8b72nlvv6kmlzQxyVfLqTFUUGfo5lRfbc8xQ5/UmLo+xaWw1r+LA18YWr3fVHZvt3p1bWmnoVl6pcSmzGi30trsv5buNTUg3KOsNvuvN8tMdbFJ49rsvz6oNHWoSbqhzVhsO2xoe62paakuBbRutMUOQxuqTF2V5FJk6/7rcJP0drlNl8S51adbSzvNbun5IpuGRro1NNLX9kv7TMWGSJfE+dp5t8LUCbd0VZux+LjaULHD0LQ2Y7H7qKHNh0zd0Mel0NZ3S/blHduXS9LBgwdVUVHhfZ6eni6n06nCwkJvLTU1VSEhIdq5c6e3lpCQoLi4OO++QpKioqLUp0+fdu/H38TweDyeb5/tzDMMQ2+88YYmTpwoSdq0aZNGjRqlyspKxcXFeee7/vrrZRiGXn75ZT300EN69tlnVVBQ0G5Z0dHRmj9/vmbOnPmVbTmdTu8OTZIcDocSEhJUV1cnu93eqeuVfPfKTl0eYDWlf5ng7y50CrZ14Oudqe3c4XAoPDz8W9+/z9nTWLGxsZLU7tPTqeenpsXGxqqmpqbd9JMnT6q2ttY7z1cJDg6W3W5v9wAAANZ0zoadlJQUxcbGat26dd6aw+HQ5s2blZWVJUnKysrSsWPH2p1C+uCDD+R2uzVy5Miz3mcAAHDu8es1Ow0NDe3Or5eUlGj79u3q0aOHEhMTNXfuXP35z39WamqqUlJSdP/99ys+Pt57qmvQoEEaN26cbr/9di1evFjNzc2aPXu2Jk+ezJ1YAABAkp/DztatWzV69Gjv83nz5kmSpk+frqVLl+quu+5SY2OjZsyYoWPHjunCCy/Ue++9py5dunhf88ILL2j27Nm67LLLZJqmJk2apIULF571dQEAAOemc+YCZX/6rhc4dQQXLQLfjAuUAevjAmUAAIAziLADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAszTJhZ9GiRUpOTlaXLl00cuRIbdmyxd9dAgAA5wBLhJ2XX35Z8+bN0wMPPKBt27ZpyJAhys7OVk1Njb+7BgAA/CzA3x3oDI899phuv/123XLLLZKkxYsXa+XKlfr3v/+tu++++0vzO51OOZ1O7/O6ujpJksPh6PS+uZ1fdPoyASs5E9udP7CtA1/vTG3np5br8Xi+eUbPD5zT6fTYbDbPG2+80a4+bdo0z5VXXvmVr3nggQc8knjw4MGDBw8eFnhUVFR8Y1b4wR/ZOXz4sFwul2JiYtrVY2Ji9Pnnn3/la+655x7NmzfP+9ztdqu2tlaRkZEyDOOM9hf+43A4lJCQoIqKCtntdn93B8AZwrb+v8Pj8ai+vl7x8fHfON8PPux0RHBwsIKDg9vVIiIi/NMZnHV2u50dIPA/gG39f0N4ePi3zvODv0A5KipKNptN1dXV7erV1dWKjY31U68AAMC54gcfdoKCgjRs2DCtW7fOW3O73Vq3bp2ysrL82DMAAHAusMRprHnz5mn69OkaPny4LrjgAj3xxBNqbGz03p0FSC2nLx944IEvncIEYC1s6/hvhsfzbfdr/TA89dRT+utf/6qqqiplZGRo4cKFGjlypL+7BQAA/MwyYQcAAOCr/OCv2QEAAPgmhB0AAGBphB0AAGBphB0AAGBphB0AAGBphB1Yntvtlsvl8nc3AAB+QtiBpe3Zs0fTpk1Tdna2Zs6cqU2bNvm7SwDOAD7Q4JsQdmBZBQUF+vGPfyyXy6URI0YoJydHv/71r7Vw4UJ/dw1AJyosLNQTTzyhgwcP+rsrOEdZ4ucigP/m8Xj03HPPKTs7Wy+++KIk6d5779XChQu1ZMkSNTU16a677vJzLwGcrqKiImVlZeno0aM6cuSI5s2bp6ioKH93C+cYwg4syTAMVVZWqqqqylvr1q2bfvWrX6lLly566aWX1KtXL02ZMsWPvQRwOhobG7VgwQJdeeWVGjFihGbPnq2TJ0/qrrvuIvCgHcIOLMfj8cgwDP3oRz/S3r17VVBQoAEDBkhqCTw///nPVVBQoKefflpXX321unbt6uceA+gI0zQ1bNgwRUZG6oYbblBUVJQmT54sSQQetMNvY8GyiouLlZmZqSuvvFJPPvmkwsLCvEGooqJCSUlJWrVqlcaNG+fvrgLooMbGRoWGhnqfv/zyy7rxxhv1m9/8RnfffbciIyPldrtVVlamlJQUP/YU/sSRHVhW37599corr2j8+PEKCQnRH//4R+8nvcDAQA0ePFjh4eF+7iWA03Eq6LhcLpmmqRtuuEEej0c33XSTDMPQ3Llz9eijj6qsrEzPP/88R3L/RxF2YGmjR4/W8uXLdd111+ngwYO6/vrrNXjwYD333HOqqalRQkKCv7sIoBPYbDZ5PB653W5NnjxZhmFo6tSpevvtt1VcXKzc3FyCzv8wTmPhf8K2bds0b948lZaWKiAgQDabTS+99JKGDh3q764B6ESn3tIMw9Bll12m7du3a/369UpPT/dzz+BPhB38z3A4HKqtrVV9fb3i4uK4eBGwKJfLpTvvvFNPPPGEtm/frsGDB/u7S/AzTmPhf4bdbpfdbvd3NwCcBeedd562bdtG0IEkjuwAACzo1J2XgMTPRQAALIigg7YIOwAAwNIIOwAAwNIIOwAAwNIIOwAAwNIIOwAAwNIIOwAAwNIIOwAAwNIIOwAAwNIIOwAAwNL+P7XbycKVAzzIAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "from qiskit.visualization import plot_histogram\n",
+    "from qbraid.visualization import plot_histogram\n",
+    "\n",
     "plot_histogram(counts)"
    ]
   },
@@ -186,24 +276,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWMAAABuCAYAAADyK3KLAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAAKGUlEQVR4nO3da3BU5R3H8d/mviEJg1BIIgjhskAwgTYxmAEUvNDqDJXWKVgBo1L6QgXsxAStcXCgNuVSZZCpgw5eQKVJb6MyTmVaJVCKEkQEIRBuoYRklUgUyGWTzZ6+yEiLBiTJyZ5n1+9nJm9yTp7zZzl8OTnZ7Losy7IEAHBUhNMDAACIMQAYgRgDgAGIMQAYgBgDgAGIMQAYgBgDgAGIMQAYgBgDgAGIMQAYgBgDgAGIMQAYgBgDgAGIMQAYgBgDgAGIMQAYgBgDgAGIMQAYgBgDgAGIMQAYgBgDgAGIMQAYgBgDgAGIMQAYgBgDgAGIMQAYgBgDgAGIMQAYgBgDgAGIMQAYgBgDgAGIMQAYgBgDgAGIMQAYgBgDgAGIMQAYgBgDgAGinB4gnFmWJfl8To/RObGxcrlcti1nWZYam/y2rRcM8e4o2x4Dy7LkbwqtcyDKbfc5IDW32bZcj4uLlGz8418xYtyTfD75Z+Q5PUWnRJW+IsXF2bZeY5NfCdevt229YDj//j3qFR9ty1r+Jp9eGzbblrWCZdbRVxUdb9850NwmTXrbtuV63LbbJbcDZeQ2BQAYgBgDgAGIMQAYgBgDgAGIMQAYgBgDgAGIMQAYgBgDgAGIMQAYgBgDgAGIMQAYgBgDgAGIMQAYIOxiXFdXp8LCQg0fPlxxcXEaNGiQFi5cqIaGBs2dO1cul0tr1qxxekwAuEhYxXjPnj3KyMjQihUr5PV6lZ6ertbWVq1evVozZ85URUWFJGncuHHODtpJZXWfKeatUj199OAl94l5q1TTP9gWxKmC66kFWbL2ztV900d0uP29dberede9GjO8T5AnC57JL+TrnuoS9c8Z1eH2/jmjdE91iSa/kB/kyYLjwztcV/Rxbt8Wp0ftkrB5PeO6ujpNmzZNXq9X+fn5Wrx4sRITEyVJy5cv16JFixQV1f6i4ZmZmQ5Pi8568g8fadqN1+jpR8Zr845TOvVp44VtD88eo8nXpejRVeXaf6TewSl71o5HX9CA8aM1cdWDevPmRy560fpId4wmrnpQvjPntGPR8w5O2XOG/GrDJbf5vMdUu3GxopL6Ke7qkUGcyj5hc2W8YMECVVdX66GHHtLKlSsvhFiSCgsLNXbsWPn9fg0ZMkRJSUkOToquaPUHlFe0Vb3c0Vr35KQLn/cM6a2n5mfr/b2facXL+xycsOf5Pj+rHYVrlZSWoqwn5ly0Lfvx2UpKS9G/C9bKd+acQxP2rL6TZ3f40Sf3p/pix1+kiEilFZQo+qoUp0ftkrCIcUVFhUpKStSvXz8VFxd3uE9WVpYkaezYscEcDTb6qOJzFa/7WD+cMFDz7hypiAiX1j91g1wuKa9oqwIBy+kRe9x//l6uI38q06i8qUqZmCFJSs4do1H3/UhHSrfo5DvlDk8YfFWr71dT1V4NzFumpMybnB6ny8Iixhs3blQgENCsWbOUkJDQ4T5ut1tSaMe4sa1NdT5fhx/fFUuf/0h7Dn6ulfk5evaxXI3P6K/Hn/1QlVVfOj1a0OwsWqfG2jOa8MwDcg/oownPPKDG2jP6oOhFp0cLOu9fV6j+XyXqM3GmBkwP7XvlYXHP+N1335UkTZky5ZL7VFdXSwrtGC85tF9LDu13egxH+f2W8oq2qnzjj/XAzNHatturVa9+4vRYQdVytlHb85/T1D8+oTv+uVKxfRK1+ee/Ueu5xm//4jByds8/dGrDY3IPztDg+eucHqfbwiLGJ06ckCQNHjy4w+1+v1/bt2+X1L0YZ2dny+v1XvH+7ogIHRiX2+Xjfd0vrhmqO1MHdbjttvfLbDmGx+NRUyBgy1qSFFC0dFWRbetJ0pfnW+RraVNMdKTe3nZSls13J0Z4PIpQqy1rRVsRWqwcW9b6fzVlH+vQhs0aOWeqDm3YrNqte21b2zPCo1aXfeeAK8atAasO27aeJPk+rdKxlXcp0p2oYY/9TZFxvWxb2+MZIaulqctfn5ycrF27dnX668Iixg0NDZKkpqaOH8CSkhLV1dUpMTFRaWlpXT6O1+vVqVOnrnj/+MhIaVyXD/cNwxMSdPP3Bti3YAdqamrU2Gbj+6q7YqSr7FtOkl5aMkkx0ZE6cLReRb8cp9J3jutYtX0/tKqtqZGsFlvWinFFSj30V3Z6V6VGzpmq07sqbV23prZGLZZ950BEbLytD0HA16ijxT9RW0O9hhdtUmzKMBtXb/83EPAF/7uMsIhxcnKy6uvrtXv3buXmXnwlWltbq4KCAklSZmamXC5Xt47TGe6I0Lsln5qaavuVca1tq0nz707XlJxU/Xr1Lr3x3gntLpmuF5dM0uT77Xsv+JTUVFuvjGXfwxkUqSmptl8Z2+nEmnlqOr5HqbOWqnfWbbauLbX/G+julXFXhEWMb7nlFlVUVGjZsmW69dZb5fF4JEnl5eWaM2eO6urqJHX/lz06+62H1dws/4y8bh0z2CorK+WKi7NtvYbGViVcv96WtYZfk6Tihdnaue+0lr24V4GApSef263ihddp/t3pevb1A7Yc53BlpXrFR9uyVmtjs14bNtuWtYKl8nClouPtOwea/NIkm/6v/PSNp3Vm6+vqPf4OJf/scXsW/ZrKysNyO1DG0Lt060BhYaH69u2rkydPasyYMcrIyNCIESOUk5OjoUOH6qab2p/uEso/vPuuc7mkl5feoMgIl/KKyi48jW35S/tU/slpFS/M1tCBid+yCkLZub3vqfrlQsVePVJpD6/v1ne5JgqLK+OBAwdq27ZtKigoUFlZmaqqqpSenq61a9dq3rx5Gjas/Z4SMQ5d+XkZmvD9ASp8ZqcOHv/f09gCAUv3PrG1R25XwBytZ2p1bMUMKdCmPrl36oudb15yX/eQTMUPCb3fsg2LGEvS6NGjtWnTpm98/vz586qqqlJERISuvfZaByZDd41K662lD/5AOz7+TL9/5ZtPYztw9IseuV0BczSfOiT/2fbbjd4///ay+6bctZgYm2j//v2yLEsej0fx8fFOj9MlN/brr5ZpMy67z7dtD2UHj38p93WvXHaf363bq9+ts+/pXaHgSOkWHSnd4vQYQZGYMVlZb4T3b1iGxT3jy9m3r/31CrhFAcBkxBgADECMAcAAYX/P+KvXrQAAk4X9lTEAhAJiDAAGIMYAYABiDAAGIMYAYABiDAAGIMYAYABiDAAGIMYAYABiDAAGIMYAYACXZdn9Ruf4imVZks/n9BidExtr69vZWJalxia/besFQ7w7yrbHwLIs+ZtC6xyIctt9DkjNNr7heE+Li2x/m69gI8YAYABuUwCAAYgxABiAGAOAAYgxABiAGAOAAYgxABiAGAOAAYgxABiAGAOAAYgxABiAGAOAAYgxABiAGAOAAYgxABiAGAOAAYgxABiAGAOAAYgxABiAGAOAAYgxABiAGAOAAYgxABiAGAOAAYgxABiAGAOAAf4LQWHdS8eQSLIAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 436.286x117.056 with 1 Axes>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "circ = QuantumCircuit(1) # we omit the second argument as we will just draw the circuit, \n",
+    "circ = QuantumCircuit(\n",
+    "    1\n",
+    ")  # we omit the second argument as we will just draw the circuit,\n",
     "# without measuring.\n",
     "\n",
-    "circ.h(0) # Adds a Hadamard on the zeroth qubit.\n",
+    "circ.h(0)  # Adds a Hadamard on the zeroth qubit.\n",
     "\n",
-    "circ.x(0) # Pauli X\n",
+    "circ.x(0)  # Pauli X\n",
     "\n",
-    "circ.y(0) # Pauli Y\n",
+    "circ.y(0)  # Pauli Y\n",
     "\n",
-    "circ.z(0) # Pauli Z\n",
+    "circ.z(0)  # Pauli Z\n",
     "\n",
-    "circ.draw(output='mpl')"
+    "circ.draw(output=\"mpl\")"
    ]
   },
   {
@@ -217,24 +321,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAATEAAADuCAYAAABRejAmAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAAXrElEQVR4nO3df1yVdZ738dc5Ij+FFCGPigKmmBBoI5L0wwZX7zuHbCrzHicru8e2nS3TerjSbDXbmDsps+7cO+o0t87dz92Gpaw2f9TdNFlJTBpElgFGIbjy42hH1ADxB5yzfzCykUfk4PnB9/B+Ph49esR1Xef69ABeXNfFdR0sLpfLhYiIoayBHkBE5GIoYiJiNEVMRIymiImI0RQxETGaIiYiRlPERMRoipiIGE0RExGjKWIiYjRFTESMpoiJiNEUMRExmiImIkZTxETEaIqYiBhNERMRoyliImI0RUxEjKaIiYjRFDERMZoiJiJGU8RExGiKmIgYTRETEaMpYiJiNEVMRIymiImI0RQxETGaIiYiRlPERMRoipiIGE0RExGjKWIiYjRFTESMpoiJiNEUMRExmiImIkZTxETEaIqYiBhNERMRoyliImI0RUxEjKaIiYjRFDERMZoiJiJGU8RExGiKmIgYTRETEaMpYiJiNEVMRIymiImI0QZExBwOB3l5eYwfP57w8HDGjBnDsmXLaG1tZfHixVgsFjZs2BDoMcVHXC4XO0sb+emqYm5e9jbzHnqHh//PR1TVHg/0aOIFFpfL5Qr0EL60Z88e5syZg91uJyoqipSUFBoaGjh06BC5ubk0NTXx4YcfUlRUxLXXXhvoccXL3iquY/na3ZRXH3O7fHb2KJ569BrGj43x72DiNUEdMYfDwZVXXkldXR3Lly/n8ccfJzo6GoBf/epXPPzww4SEhNDR0cGxY8eIidEXcjApeKOaOx99n46Onr/E44aFs+P3c0hPifXTZOJNQR2x22+/nYKCApYsWcL69evPWT5lyhQ+/fRTkpOT2b9/fwAmFF/5aO/XXLtoG2fanb1aP2FEFJ+/eiuXRIf6eDLxtqC9JlZZWUlhYSFxcXGsXr3a7TpTp04FYPLkyd0+XlNTw0033UR0dDTDhg3jrrvu4siRIz6fWbznn577rNcBA6g71MoLW7/04UTiK0EbsYKCApxOJwsXLmTIkCFu14mIiAC6R6y5uZmcnBzq6uooKChg06ZNFBUVceONN+J09v6bQgKn4XArr+044PF2TxVWEsQnJkErJNAD+MqOHTsAyMnJOe86dXV1QPeIbdq0ifr6enbu3MnYsWMBSEhI4Oqrr2bLli3cfPPNvhtavOJPuxoueB3MnX01xznQ0ELS6GgfTCW+ErQRO3Cg8ydxYmKi2+Xt7e0UFxcD3SO2bds2rr322q6AAWRnZzNu3Di2bt3ap4hlZmZit9s93k76piXsKoj6QZ+2zbo6h9AOfa78zWazUVpa2qdtgzZira2tALS1tbldXlhYiMPhIDo6muTk5K6PV1RUMH/+/HPWT0tLo6Kiok+z2O126uvr+7St9MGwQxDVt02/th+E04e9O4/4VNBGzGazcfToUcrKysjOzu62rLGxkRUrVgCQkZGBxWLpWnb06FGGDh16zuvFxsbyxRdf9HkW8Z8zg05wGMDlgm99bi/E6mzBFh+OhdE+m03cu5jvkaCN2KxZs6isrCQ/P5/Zs2eTkpICQElJCXfeeScOhwPovM3C1/p6mCx9d92ibXzwySGPtvnZvdfwy6XLfDSR+ErQ/nYyLy+P4cOHc/DgQdLS0khPT2fChAlkZWUxbtw4Zs6cCZx7e8WwYcM4duzYOa/X1NREbKxuhjTFg3ekebR+eNgg7r1too+mEV8K2oglJCRQVFREbm4u4eHh1NbWEhsby8aNG9m+fTtVVVXAuRGbNGmS22tfFRUVTJo0yS+zy8WbNzuZ5Xdd0at1rVYLL67+Pomj9FtJEwX1Hfvn09LSQkxMDBaLhebmZiIjI7uWrV27lkceeYT9+/eTkJAAwO7du5k+fTqvvvoqt9xyS6DGFg+5XC6e/P2nPLHxE06fcX+PX9ywcJ5bdR25M8a6XS7934CM2NkoTZw4kX379nVb9s0335Cenk5cXBwrV67k5MmT5OXlER8fz4cffojVGrQHr0HLcfQkz/5HFS++Uc3eL5twOiF0sJWnV17HbbOTCA8L2kvDA8KA/I7cu3cvcO6pJEBMTAw7duxg5MiRLFiwgHvuuYerr76abdu2KWCGihsWzor/ncGel29hZFznUXf8sHDuuHG8AhYEBuRnsKeIAVx22WVs27bNnyOJSB8NyEOLC0VMRMwxII/Ezj5XKSLmG5BHYiISPBQxETGaIiYiRlPERMRoipiIGE0RExGjKWIiYjRFTESMpoiJiNEUMRExmiImIkZTxETEaIqYiBhNERMRoyliImI0RUxEjKaIiYjRFDERMZoiJiJGU8RExGiKmIgYTRETEaMpYiJiNEVMRIymiImI0RQxETGaIiYiRlPERMRoipiIGE0RExGjhQR6AHHP5XJxoq090GP0WmRECBaLJdBjyACkiPVTJ9raGTL9hUCP0Wstu+4iKnJwoMeQAUinkyJiNEVMRIymiImI0RQxETGaIiYDhtPpwuVyAXT9W8yn305K0Kqzt7L57RpKKxx8XOHgi9rjnG1Xw9dtTPvx60xNjSM741LmzU5iiH67aiSLSz+S+qXWE2d0i0UfvVfSyPo/VPD6ewfo6Ojdl3d01GDumjueB36cysTkob4dULxKEeunFDHPHTl2kqVrdvGHN6r7/BqDQ6w8/tMrefgnGYSE6GqLCfRZkqDwzq4G0m559aICBnCm3cljGz5m+h1bqalr9tJ04kuKmBjvtXdqmXPfWxw60ua11/y4wsG1d29jX80xr72m+IYiJkZ7q7iOH614lzPtTq+/dsPhE8z66zeprdcRWX+miImxDh1pY+Hfv+eTgJ1Vf/gEdzzyPh0dvtuHXBxFTIzkcrn4238s5sixUx5tV1JwEwffXkBJwU293qb4k0Os/0OFpyOKnwyIiDkcDvLy8hg/fjzh4eGMGTOGZcuW0drayuLFi7FYLGzYsCHQY4oHtr73n7z2zgGPt7PFRZIwIgpbXKRH2z2yvpSGw60e768/sZ+APx+G9xrhkyPgwwNYvwr6m1337NnDnDlzsNvtREVFkZqaSkNDA+vWraO6upqmpiYApkyZEthBfeSXS6fyyD1T+Mk/7OTZ//jynOXvPv0DsidfytQFr1P+1dEATNg3v3mx3K/7azvZwe9f+YLH//Z7ft2vN/z5MLxUA8WH4Nv3U8WFwS2JcFsSDA8P1HQXL6iPxBwOB3PnzsVut7N8+XIaGxspKyvDbreTn5/P9u3bKSkpwWKxkJGREehxfeIXT33C3i+b+PXfXcXoEd2PPh68I43vTxvJ40+VGRWwyv3H2PFRo9/3u+mVLzhzxpzDF5cLfv05LN0FH3wnYACOU/D7KrhjJ1QdD8iIXhHUEVu6dCl1dXUsWbKEtWvXEh0d3bUsLy+PyZMn097eTlJSEjExMQGc1HfOtDtZ9NhOoiIG8/Qvruv6eErSJfzygUx2fXaYf3pubwAn9NyL278KyH4bDp9gx0cNAdl3X/xuH/xh/4XX+/okLPkQ6g09Ww7aiFVWVlJYWEhcXByrV692u87UqVMBmDx5ctfHzkYvKyuLsLCwoHjL5U8qj7D66U/5n9ck8NfzJmK1WnjhlzOwWGDRYztxOs16aOOjz78O2L5LygO3b0/UtcIz5149OK+m0/DUPt/N40tBG7GCggKcTicLFy5kyJAhbteJiIgAukfsq6++4pVXXsFmszFt2jS/zOoPqzZ9wp59R1i7PIv1f5/NVemX8uj6j6mqNes8wuVyUVruCNj+A7lvT7xS6/k27zTAkZNeH8XngjZiO3bsACAnJ+e869TV1QHdIzZjxgwaGxvZsmULs2bN8u2QftTe7mLRYzsJDxvEfT+aRFGZnX/5t88DPZbH7I42jn5zOmD7L68+FrB9e2LrQc+3aXfBW/Xen8XXgva3kwcOdP76PTEx0e3y9vZ2iouLge4Rs1q93/XMzEzsdrtH2zgZDLGPeXWO4y2nOXW6g9DBg3ij6CDefPR/QkoKVs547wXPo90aC0OXnXd5ScFNPd4+YYuL6Pr3wbcXnHc9u+ME03685ZyP76+tJyEhwYOJAyAkDNu6vj1Duuo3G8l7dZWXB7owm81GaWlpn7YN2oi1tnZepWxrc/88XWFhIQ6Hg+joaJKTk306i91up77ewx9xllCI9e4czz5xHaGDB1FRfZTH7p3CS2/VsN9LDzk3NjSAyw9HSKFnYOj5F5+9D+xCQgZZe7Xedzk7Ojz/XPqZJSQUWx+3bW5u7vf/f98VtBGz2WwcPXqUsrIysrOzuy1rbGxkxYoVAGRkZPj84r3N5vmXlJPBePMmggduTyUnaxSPrCvl9XcPUFZ4M888cR3f/8kbXnn9kaNG+eVIrMMyhJ6Oae2OEz1ub4uLIGSQlfYOJ3bH+R8YP9/rDLJ2YBs9ujejBlRHs4NB0XEebxfZ3szoAPz/9eV75KygjdisWbOorKwkPz+f2bNnk5KSAkBJSQl33nknDkfnBVp/3OTal8Nkb76f2PixMaxelslHe78m/5nPcDpd/OJ3ZaxeNo0Hbk/1yiM1X1ZV+eX9xFwuF3EzXqTpuPvHjdydAn7bwbcXkDAiCrujjTGz/93j/c+d/T1e+5c6j7fzt3UV8IKHd6IMtsKu/7eS2LCVvhnKR4L2wn5eXh7Dhw/n4MGDpKWlkZ6ezoQJE8jKymLcuHHMnDkT6H49LBhZLPDcqhkMslpY9Nj7XbdT/OrZvZR8/jWrl2UyLiH6Aq/Sf1gsFqamDg/Y/gO5b0/cmgienl/MGgmxYT4Zx6eCNmIJCQkUFRWRm5tLeHg4tbW1xMbGsnHjRrZv305VVRUQ/BFbviida64cwT88Vca+mv++ncLpdHH3z3cSMsjKM09c18Mr9D9XpV8asH1nXREfsH17IiEK7knp/frDw+C+Sb6bx5eCNmIAkyZNYtu2bTQ3N9Pc3Mzu3bu59957aW1tpba2FqvVyhVXXBHoMX3m8uRLWHX/9/jw08P88/Pn3k5RUX2MX/yujOszR/LA7akBmLBv7si9LCD7HX1pJDOzRgVk331x70RYNP7C640Ih99mw0jPnonvN4L2mlhPysvLcblcpKSkEBl57mdu8+bNAFRUVHT776SkJDIzM/036EXaV3OciGnP97jOmqc/Y83Tn/lpIu+YmDyUWdNH8add/n0E6G/mX27U++5bLPBAKlwV3/kA+E47fPvJzxHhcEsSzEuEYQaeRp41ICO2d2/ns4LnO5WcP3++2/9etGgRzz33nE9nk9558I40v0YsMjyEe26d6Lf9eVNWfOc/h9sg9+3OB8EtwOuzwKAmn5ci5ob+AFT/lztjLPP/RzIv/7HGL/tb82AmI+MNPd/6i0sjOuN1NmLBEDAI8mti53OhiIkZfvtINnHDPHsjLLvjBHWHWi94P9m3XZ9p4/4F5lwzHGgG5JHY2ecqxWzxsRH8e34OP7j/LU738n2+LnQf2XeNsUXxr09ej9Vq/ruZBKsBeSQmweOvpo/i5bUzCR3s/S/lhBFR/GnTHMbY3L8LivQPipgY76acRN76vzcw6lLvXbPKuiKeD57PJSXpEq+9pviGIiZB4fvTRvL5q7dy9w8nXNTrhIUOIv/BaRS/cCOJo8x5kmEgU8QkaAyLCePZVTP44Pkb+dENyYSE9P461tDoUB66M43y124l7ycZRt0PNtANyAv7EtyuuXIE11w5ArvjBK/8qZbScgcfVzjYV3O86w/tRkWEkJESy9TUOKZnxHPLzCQiI/TtYCJ91iRo2eIiz7k1or3didVq0W8bg4giJgOKThODjz6jImI0RUxEjKaIiYjRFDERMZou7PdTkREhtOy6K9Bj9JpuT5BA0VdeP2WxWPzyhzdETKfTSRExmiImIkZTxETEaIqYiBhNERMRoyliImI0RUxEjKaIiYjRFDERMZoiJiJGU8RExGiKmIgYTRETEaMpYiJiNEVMRIymiImI0RQxETGa3tm1n3K5XHDqVKDH6L2wMCwW/UFa8T9FrL86dYr2/7Uo0FP0WshLz0N4eKDHkAFIp5MiYjRFTESMpoiJiNEUMRExmiImIkZTxETEaIqYiBhNERMRoyliImI0RUxEjKaIiYjRFDERMZoiJiJGU8RExGgDImIOh4O8vDzGjx9PeHg4Y8aMYdmyZbS2trJ48WIsFgsbNmwI9Jg+8b7jMKFbX+LX1fvOu07o1pe4eXeRH6cSf2p3wjsNcN+fwfmXjzmB35RDXWsgJ/OOoH8/sT179jBnzhzsdjtRUVGkpqbS0NDAunXrqK6upqmpCYApU6YEdlARH/j8KDxcCofazl32r9Xwb9VwcyLkpcNgQw9pDB27dxwOB3PnzsVut7N8+XIaGxspKyvDbreTn5/P9u3bKSkpwWKxkJGREehxRbzqsyb4m2L3ATvLBbx2oDN0HS6/jeZVQR2xpUuXUldXx5IlS1i7di3R0dFdy/Ly8pg8eTLt7e0kJSURExMTwElFvOtkO/zdR3DKeeF1AXba4YWvfDuTrwRtxCorKyksLCQuLo7Vq1e7XWfq1KkATJ48uetjmzdvZt68eSQmJhIZGcnll1/Oo48+SktLi1/m9pUTHR04Tp1y+48En/9fD02nPdvmpZrO62emCdprYgUFBTidThYuXMiQIUPcrhMREQF0j9jatWsZO3YsTz75JAkJCezZs4eVK1fy/vvvs3PnTqxWM7v/xBflPPFFeaDHED/ZXOv5Nl+f7DwimznK6+P4VNBGbMeOHQDk5OScd526ujqge8S2bt1KfHx8139ff/31xMfHs3DhQj744ANmzJjh8SyZmZnY7XaPtomwWqmYku3xvs7nnrHjmDdqjNtlc3a9f9Gvn5KSQpvTwB/jwchixfbb/+zTpvf943patuR7eaALs9lslJaW9mnboI3YgQMHAEhMTHS7vL29neLiYqB7xL4dsLMyMzMBqK+v79Msdrvd420jBw2CKX3anVvjhwzhr+JHeO8Fv6OhoYETHR0+e33pPWtYJLY+btt6xtnnr/NACdqItbZ23gDT1ub+VzOFhYU4HA6io6NJTk7u8bXeffddACZNmtSnWWw2z7+kIgw7bR01apSOxPoRV8cZLIMGe7xdlNXJ6NGjfTBRz/ryPXJW0EbMZrNx9OhRysrKyM7uflrW2NjIihUrAMjIyOjxj77W19fz85//nBtuuKHP95L15TDZdfKkUX93sqqqCov+7mS/8dBuKDrk+Xab1zzEFRsf8v5APmTWj3sPzJo1C4D8/Hyqqqq6Pl5SUkJOTg4OhwPo+SbXlpYWfvjDHxIaGsozzzzj03lFvGl+zycXbl1+CaQN9fooPhe0EcvLy2P48OEcPHiQtLQ00tPTmTBhAllZWYwbN46ZM2cC3a+HfVtbWxtz586lpqaGP/7xj4wcOdKf44tclOnxngdpcQr0cFLSbwVtxBISEigqKiI3N5fw8HBqa2uJjY1l48aNbN++vevozF3Ezpw5w2233UZpaSlvvvkmqamp/h5f5KJYLfDrLEh0f3fROZalQo6hP6ctLpfL0IcN+q6lpYWYmBgsFgvNzc1ERkZ2LXM6nSxYsIAtW7bwxhtvdB2x+Ztp18RCXnpe18T6oeOnYe1eeLsB2t18pydEwk8vhxsS/D+btwTthf2elJeX43K5SElJ6RYwgPvvv5+XX36Zn/3sZ0RGRrJr166uZZdddpnbWzBE+qtLQmHVVHgwDbYehOpvOh9FuiQUZo6Eq+I7j9pMNiAjtnfvXsD9qeSbb74JwJo1a1izZk23Zc8++yx33323z+cT8bbh4XD3hEBP4RuK2HfU1tb6eRoRuRhBe2G/Jz1FTETMMiCPxM4+Vyki5huQR2IiEjwUMRExmiImIkZTxETEaIqYiBhNERMRoyliImI0RUxEjKaIiYjRFDERMdqAfD8xE7hcLjDpD9uGhfX4twpEfEURExGj6XRSRIymiImI0RQxETGaIiYiRlPERMRoipiIGE0RExGjKWIiYjRFTESMpoiJiNEUMRExmiImIkZTxETEaIqYiBhNERMRoyliImI0RUxEjKaIiYjRFDERMZoiJiJGU8RExGiKmIgYTRETEaMpYiJiNEVMRIz2X3F+3RDVGRrAAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 371.107x284.278 with 1 Axes>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "circ = QuantumCircuit(3) # the first argument specifies that we are building a circuit \n",
+    "circ = QuantumCircuit(3)  # the first argument specifies that we are building a circuit\n",
     "# of 3 qubits.\n",
     "\n",
-    "circ.h(2) # Adds a Hadamard on the third qubit (Python starts counting from zero..)\n",
+    "circ.h(2)  # Adds a Hadamard on the third qubit (Python starts counting from zero..)\n",
     "\n",
-    "circ.x(1) # Adds a Pauli X on the second qubit\n",
+    "circ.x(1)  # Adds a Pauli X on the second qubit\n",
     "\n",
-    "circ.cx(0,1) # Adds a CNOT gate on control qubit 0 and target qubit 1.\n",
+    "circ.cx(0, 1)  # Adds a CNOT gate on control qubit 0 and target qubit 1.\n",
     "\n",
-    "circ.cz(1,2) # Adds a Controlled-Z gate on control qubit 1 and target qubit 2. \n",
+    "circ.cz(1, 2)  # Adds a Controlled-Z gate on control qubit 1 and target qubit 2.\n",
     "\n",
-    "circ.draw(output='mpl')"
+    "circ.draw(output=\"mpl\")"
    ]
   },
   {
@@ -246,21 +362,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPEAAADuCAYAAADoS+FHAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAASSklEQVR4nO3dfVDUh53H8c8uII9LeIwrLIhEMYiCiWjEaiIWjKgY7xKTNNZ4p8ZeW6u5s3Jzmbk82KkcF710rLXVhokmnRBSk1gETRsDUbRGUTQ1gnJyYnjYtVlBQcAH2L0/UEbCorvL7v72u3xeM5mM+9vf7/d13De/h11AZTabzSAisdRKD0BEg8OIiYRjxETCMWIi4RgxkXCMmEg4RkwkHCMmEo4REwnHiImEY8REwjFiIuEYMZFwjJhIOEZMJBwjJhKOERMJx4iJhGPERMIxYiLhGDGRcIyYSDhGTCQcIyYSjhETCceIiYRjxETCMWIi4RgxkXCMmEg4RkwkHCMmEo4REwnHiImEY8REwjFiIuEYMZFw3koPQP2ZzWbgxg2lx7CNry9UKpXSUwxJjNgd3biBrmeXKj2FTbw/3An4+Sk9xpDE02ki4RgxkXCMmEg4RkwkHCMmEo4REwnHiImEY8REwjFiIuEYMZFwjJhIOEZMJBwjJhLO4yM2Go3IycnB6NGj4efnh5iYGKxZswbt7e1Yvnw5VCoVtmzZovSY5ETd3SYUlV3EP//nQSz42Wd49uel+MW2k9B/26H0aA7h0d+KeOrUKWRlZcFgMCAwMBDjxo1DU1MTNm/ejNraWjQ3NwMAJk6cqOygTnLA+HdkHvkC/zUuGf/20MMWnzNsz4eY++AI7H5shounc413dtfg9d9W4ht9e5/H//iXC1j/u5N4JnMUtryShvAQud9G6bFHYqPRiOzsbBgMBqxduxZ6vR6VlZUwGAzIy8tDSUkJKioqoFKpkJycrPS45ATrf3cSy14t7xfwHV3dZnzw6f9h2pJiGIxyj8oeG/Hq1avR0NCAVatWYePGjdBoNL3LcnJykJKSgq6uLsTFxSE4OFjBSckZPthXi9e2Vlr13JqLV/HU6v0wmcxOnso5PDLi6upqFBYWIiIiArm5uRafM2nSJABASkpKn8cvXLiABQsWQKPRIDQ0FC+++CIuX77s9JnJccxmM375+69sWufY199i/5eNTprIuTwy4oKCAphMJixevBhBQUEWn+Pv7w+gb8RtbW1IT09HQ0MDCgoKsH37dpSXl2P+/PkwmUwumd0ZOrq7Ybxxw+J/nuhQ5SV8fb7F5vW2FlY7YRrn88gbW6WlpQCA9PT0AZ/T0NAAoG/E27dvR2NjIw4ePIjY2FgAgE6nw7Rp01BUVISFCxc6b2gnWn/uDNafO6P0GC7z6eEGu9bbd6gBZrNZ3A/888iIL168CAAYOXKkxeVdXV04fPgwgL4RFxcXY/r06b0BA0BaWhri4+OxZ88euyNOTU2FwWCw+vn+ajWqJqbZtS9LVsTG4+moGIvLsr484JB9JCQkoNNNzlauBMwF/B6zeb2bt0zQxYyCCl1OmOretFotjh8/bte6Hhlxe3vP3cjOzk6LywsLC2E0GqHRaDBq1Kjex6uqqrBo0aJ+z09KSkJVVZXd8xgMBjQ2Wn+9FeDlBUy0e3f9jA4KwvcjhztugxY0NTWho7vbqfuwmrYFsOcdI3M3mhovOnwcZ/PIiLVaLVpaWlBZWYm0tL5HNL1ej3Xr1gEAkpOT+5w6tbS0ICQkpN/2wsLCcO7cuUHNYwt/tbxbFVFRUW5zJO70uYpmO9bz6W7Cg9HRDp/HGra+Ru7mkRFnZGSguroaeXl5yMzMREJCAgCgoqICS5YsgdFoBOC6D3nYeppkvn5d3M+drqmpgcpNfu70rVsmjJxTaPMnsvLzFmNJ9uvOGcqJ5H3Jt0JOTg7Cw8NRX1+PpKQkTJgwAWPGjMGUKVMQHx+PWbNmAej/9lJoaCiuXLnSb3vNzc0ICwtzxejkAD4+avz0uUSb1hkRGYBFs0fd/4luyCMj1ul0KC8vx7x58+Dn54e6ujqEhYVh27ZtKCkpQU1NDYD+EScmJlq89q2qqkJiom0vClLWvy9LxoKZsfd/IoCgAG8Ubc6An6/ME1OPjBjoCbK4uBhtbW1oa2vD0aNHsXLlSrS3t6Ourg5qtRrjx4/vs878+fNx6NCh3refAODo0aOora1Fdna2q/8KNAje3mr8cdMsrHxmLO71jlG8ToOD78xDalKk64ZzMJXZbJb5WTM7HT16FFOnTsXYsWNx9uzZPstaW1sxYcIERERE4I033sD169eRk5ODyMhIHDlyBGoX3XCSeE3s/eFOt7km/q66xjZs33UOn5TWoabuKkxmwHeYGh/9z/cx53s6eHnJPpbJnt4Op0+fBtD/VBoAgoODUVpaihEjRuD555/HihUrMG3aNBQXF7ssYHK8uGgNNqxJRfWfnsGIyAAAQESIH+Y9His+YMBD707fy70iBoCHHnoIxcXFrhyJaFDkfxmy0f0iJpJmyB2J73yumshTDLkjMZGnYcREwjFiIuEYMZFwjJhIOEZMJBwjJhKOERMJx4iJhGPERMIxYiLhhtxnp0Xw9YX3hzuVnsI2vr5KTzBkMWI3pFKpADf9BntyPzydJhKOERMJx4iJhGPERMIxYiLhGDGRcIyYSDhGTCQcIyYSjhETCceIiYRjxETCMWIi4RgxkXCMmEg4RkwkHCMmEo4REwnHiImEY8REwjFiIuEYMZFwjJhIOEZMQ4bJZIbJbAYAmG//3xOozJ70tyG6y9kLV/DJ5xdxosqIE1VG1DVd612mUgHfmzgck8ZFYMajw5E9MxbDfLwUnNZ+jJg8islkxief12FrYTVKj+mtXm94uD9eenosfvJcIkZEBjhxQsdjxOQxLjS0Yflr5SirsD7e73pAMwxvrXsM//TUmJ5fpyMAIyaPsPNP/4ufbvgr2ju7HLK9uTN0+EPuTIQGu/8vimPEJN6mnafx803HHL7d5IQw7N8+B5Fh/g7ftiPx7jSJ9tvCaqcEDAB/q2nGk//yZ7Reu+mU7TsKIyaxTp29jNV5R5y6j5NnL+Nf3zzq1H0MFk+nSaSbt7ox+QdF+FtNs03rVRQsgDYiAAZjByb/oMjq9fb+ZjayZsTYOqZLDIkjsdFoRE5ODkaPHg0/Pz/ExMRgzZo1aG9vx/Lly6FSqbBlyxalxyQb/Oq9MzYHDADaiADohgdCG2Hb20gr1x/GzVvdNu/PFbyVHsDZTp06haysLBgMBgQGBmLcuHFoamrC5s2bUVtbi+bmnhfCxIkTlR2UrNbVZcKWD6pcus+GS+345POLeG5OvEv3aw2PPhIbjUZkZ2fDYDBg7dq10Ov1qKyshMFgQF5eHkpKSlBRUQGVSoXk5GSlxyUrlZTXo97Q7vL9/sbFXzis5dERr169Gg0NDVi1ahU2btwIjUbTuywnJwcpKSno6upCXFwcgoODFZyUbPHenvOK7Le88hLqGtsU2fe9eGzE1dXVKCwsREREBHJzcy0+Z9KkSQCAlJSU3sfuRD9lyhT4+vqK+dTOUHLs628V23fFGaNi+x6Ix0ZcUFAAk8mExYsXIygoyOJz/P173sS/O+Lz58/jo48+glarxeTJk10yK1nv75c7FTmVvuNEFSN2mdLSUgBAenr6gM9paGgA0Dfixx9/HHq9HkVFRcjIyHDukGSzM7Utyu7/vLL7t8Rj705fvHgRADBy5EiLy7u6unD48GEAfSNWqx3/dS01NRUGg8Hh2x2KOn0SAM1ii8vuvAd8L9oI/97/13/2/IDPG+h95L98fhA63TIbJraOVqvF8ePH7VrXYyNub+855ers7LS4vLCwEEajERqNBqNGjXLqLAaDAY2NjU7dx5ChCQc0lhfdeQ/YGt5eaqufe7ebN6673b+lx0as1WrR0tKCyspKpKWl9Vmm1+uxbt06AEBycrLTb15ptVqnbn8oueGtwUBXpQZjx33X10b4w9tLja5uEwxGy1/g77Utv2FqhEdHWzOqTQbzGvHYiDMyMlBdXY28vDxkZmYiISEBAFBRUYElS5bAaOx5KbjiQx72niZRf982d+LBme9bXGbNxyjrP3seuuGBMBg7EZP5gc37f/nHi5C75r9tXs+ZPPbGVk5ODsLDw1FfX4+kpCRMmDABY8aMwZQpUxAfH49Zs2YB6Hs9TO4vMswfMVrbT4MdZVJihGL7HojHRqzT6VBeXo558+bBz88PdXV1CAsLw7Zt21BSUoKamhoAjFiixyZEKrbvyePdL2KPPZ0GgMTERBQXF/d7/Nq1a6irq4Narcb48eMVmIwG48XsMdj1WZ3L9/tEqhYjowa4q6Ygj454IGfOnIHZbEZCQgICAvq/JbFr1y4AQFVVVZ8/x8XFITU11XWDkkVzZ+gQOyIQ3+hd+6GPnzyX6NL9WWtIRnz69GkAA59KL1q0yOKfly5dih07djh1Nro/Ly81Vr+Q5LSf6GFJ7IhA/MOsOJftzxaM2AL+nAT3t/qFJLy/txaV1Zddsr/fvzYdPj7ueQvJPadysvtFTO7Px0eNd37xOHy8bXsJG4wdaLjUbtV7yne89PRYzJ6ms3VEl+GP5yHR3v7oHF5645DTtp+aFIHSt7OgCRzmtH0M1pA8EpPnWPH0WPwq5zGnbPuRh8Oxb+uTbh0wwIjJA6z54Xj8IfcJaAJ9HLbNBTNjUZY/FxGhfg7bprPwdJo8xjf6a1jxejk+O9Jk9zZCg4fh1/+RhhfmPiTmB0IwYvIoZrMZe774BlsLq/Hnv1r/3UbRDwbgR4sexo+eeRgPhrv3b3z4LkZMHuv8N63YXXr7V5tWG1Fb3waTqeflHqIZhkceDu/91aZzZ8TA28Y73e6CEdOQcuuWCV5eKqjVMk6VrcGIiYSTef5ARL0YMZFwjJhIOEZMJBwjJhKOERMJx4iJhGPERMIxYiLhGDGRcIyYSDhGTCQcIyYSjhETCceIiYRjxETCMWIi4RgxkXCMmEg4RkwkHCMmEo4REwnHiImEY8REwjFiIuEYMZFwjJhIOEZMJBwjdgNvvvkm0tLSEBoaipCQEEyfPh2ffvqp0mOREIzYDZSWlmLZsmUoKyvDsWPHMG3aNMyfPx+HDx9WejQSgL/a1E0lJycjMzMTmzZtUnoUcnM8Ershk8mE1tZWBAYGKj0KCcCI3dCGDRtw5coVrFy5UulRSABvpQegvrZu3YoNGzagqKgIOp1O6XFIAB6J3cjGjRuxbt06FBUVISMjQ+lxSAgeid3Eq6++irfeegt79+7FE088ofQ4JAjvTruBl19+Gdu2bUNBQQGmTp3a+7i/vz8eeOABBScjCRixG1CpVBYfX7p0KXbs2OHaYUgcnk67AVu+jl6o10OnjYSPD//pqAdfCYK0XetA/od74e/ni1VLFuKB4CClRyI3wLvTghw4+hW6uroRGqxBsIYfBKEejPgu3d3deO+99zB79mxERkbC19cXsbGxmDNnDt5++210d3crNlvbtQ58eaoKAJAxfdKA19E09PDG1m2tra1YuHAhysrKAABRUVGIjo5GU1MTmpqaYDab0dLSgpCQEEXmK/78CA4dP43YqOH48Q8XMGLqxWvi25YvX46ysjLodDq8++67SE9P71126dIl5Ofnw8fHx65t/3rnx2i71mn3bGazGW3tHQAAY8tV5G593+5tkXvSBPnjZ0v/0a51GTGAEydOYNeuXfD29sa+ffswfvz4PsuHDx+OV155xe7tt13rROu19sGOCQDo6LzukO2Q52DEAHbv3g0AmDdvXr+AHUET5G/3uncfhQP8/eDt5eWosciNDOY1wogBVFX13DBKS0tzyvbtPU0CeC1M98eI0XNTC4DTPuJo7zUxr4WHDl4TD1JwcDAA4OrVq07ZviOuiXktTANhxACSkpLw8ccf48iRI07Zvj3XO7wWHloGc03M94kBnDx5Eo8++ih8fHxw6tQpjBs3TumReC1MVuMntgA88sgjePbZZ3Hr1i1kZWXhwIEDfZZfunQJubm5aG93zNtE98NPZ5EteCS+rbW1FU899RS++OILAEB0dDSioqKg1+vR2Njo0k9s8ShMtuCR+Lbg4GDs378f+fn5mDlzJjo6OvDVV19BrVbjySefRH5+PjQajUtmCQr0h5/vMB6FySo8Erup6zduwneYDyOm+2LERMLxdJpIOEZMJBwjJhKOERMJx4iJhGPERMIxYiLhGDGRcIyYSDhGTCQcIyYSjhETCceIiYRjxETCMWIi4RgxkXCMmEg4RkwkHCMmEo4REwnHiImEY8REwjFiIuEYMZFwjJhIOEZMJBwjJhKOERMJx4iJhGPERMIxYiLhGDGRcIyYSDhGTCQcIyYSjhETCceIiYRjxETCMWIi4f4fQAV6qNJXdXIAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 287.294x284.278 with 1 Axes>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "circ = QuantumCircuit(2,2) # the first argument specifies that we are building a circuit \n",
+    "circ = QuantumCircuit(\n",
+    "    2, 2\n",
+    ")  # the first argument specifies that we are building a circuit\n",
     "# of 2 qubits.\n",
     "# The second argument specifies that we'll be measuring both qubits.\n",
     "\n",
-    "circ.h(0) # Adds a Hadamard on the first qubit (Python starts counting from zero..)\n",
+    "circ.h(0)  # Adds a Hadamard on the first qubit (Python starts counting from zero..)\n",
     "\n",
-    "circ.cx(0,1) # Adds a CNOT gate on control qubit 0 and target qubit 1. \n",
+    "circ.cx(0, 1)  # Adds a CNOT gate on control qubit 0 and target qubit 1.\n",
     "\n",
-    "circ.draw(output='mpl')"
+    "circ.draw(output=\"mpl\")"
    ]
   },
   {
@@ -272,25 +402,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'00': 498, '11': 502}\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjsAAAGrCAYAAAAmWFaFAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAA/ZUlEQVR4nO3de3xU9Z3/8fc5Q24kTBISMkkkVwiXaCAIUVKsilAiYL3hApYCuip98AN3ldaqu1aL7U+s21W0i2XttqBt8UK1XrioGBa0GiEEw1UTAoEEcoVAJkRyYWZ+fyTMJD/AYghMOH09H488Hs7ne2a+3/OVc+Y955w5Y3g8Ho8AAAAsyvT3AAAAAC4kwg4AALA0wg4AALA0wg4AALA0wg4AALA0wg4AALA0wg4AALA0wg4AALA0wg4AALA0wg4AALA0v4edQ4cO6Yc//KGioqIUEhKijIwMbdmyxdvu8Xj0+OOPKy4uTiEhIRo/frz27NnT6TXq6uo0Y8YM2e12RURE6J577tHx48cv9qoAAIAeyK9h5+jRoxozZowCAgK0du1a7d69W//5n/+pyMhI7zLPPPOMXnjhBS1dulSbNm1SaGiocnJy1NTU5F1mxowZ2rVrl9atW6dVq1bp448/1pw5c/yxSgAAoIcx/PlDoI888og+/fRTffLJJ2ds93g8io+P149//GP95Cc/kSTV19fL4XBo+fLlmj59ur788kulp6crPz9fo0aNkiS9//77mjRpkg4ePKj4+PiLtj4AAKDn6eXPzt99913l5OTon/7pn7Rx40Zddtll+j//5//ovvvukySVlpaqqqpK48eP9z4nPDxcV199tfLy8jR9+nTl5eUpIiLCG3Qkafz48TJNU5s2bdJtt912Wr/Nzc1qbm72Pna73aqrq1NUVJQMw7iAawwAALqLx+NRQ0OD4uPjZZpnP1nl17Czb98+/fa3v9WCBQv0b//2b8rPz9e//Mu/KDAwULNnz1ZVVZUkyeFwdHqew+HwtlVVVSkmJqZTe69evdS3b1/vMv+/RYsWaeHChRdgjQAAwMVWXl6u/v37n7Xdr2HH7XZr1KhReuqppyRJI0aM0M6dO7V06VLNnj37gvX76KOPasGCBd7H9fX1SkxMVHl5uex2+wXrFwAAdB+n06mEhAT16dPnG5fza9iJi4tTenp6p9rQoUP15ptvSpJiY2MlSdXV1YqLi/MuU11drczMTO8yNTU1nV7j5MmTqqur8z7//xcUFKSgoKDT6na7nbADAMAl5u9dguLXb2ONGTNGRUVFnWrFxcVKSkqSJKWkpCg2Nla5ubnedqfTqU2bNik7O1uSlJ2drWPHjqmgoMC7zPr16+V2u3X11VdfhLUAAAA9mV+P7Dz44IP6zne+o6eeekpTp07V5s2b9dJLL+mll16S1JbUHnjgAf3yl79UWlqaUlJS9LOf/Uzx8fG69dZbJbUdCbrxxht13333aenSpWptbdX8+fM1ffp0vokFAAD8+9VzSVq1apUeffRR7dmzRykpKVqwYIH321hS25XWTzzxhF566SUdO3ZM11xzjV588UUNGjTIu0xdXZ3mz5+v9957T6ZpasqUKXrhhRcUFhZ2TmNwOp0KDw9XfX09p7EAALhEnOv7t9/DTk9A2AEA4NJzru/ffv+5CAAAgAuJsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAACyNsAMAuKQkJydr8ODByszMVGZmpl5//XVJ0p49e/Sd73xHgwYNUlZWlnbt2iVJampq0q233qpBgwZp+PDh+t73vqeSkhJ/rgIuMsIOAOCS8/rrr6uwsFCFhYWaNm2aJOlHP/qR5syZo+LiYj388MO66667vMvPmTNHRUVF2rZtm2655Rbde++9fho5/IGwAwC45NXU1GjLli364Q9/KEmaMmWKysvLVVJSouDgYE2aNEmGYUiSRo8erf379/txtLjYCDuwnGXLlskwDL399tuSpPz8fI0ZM0bDhw9XZmam1q9f7112z549Gjt2rDIzMzVkyBD9+Mc/ltvt9tPIAZyrWbNmKSMjQ/fcc49qa2tVXl6uuLg49erVS5JkGIYSExNVVlZ22nOff/553XLLLRd7yPAjwg4sZf/+/frd736n0aNHS5I8Ho9uu+02LVy4UNu2bdMbb7yhu+66SydOnJAkPfTQQ7rtttu8h8M//PBDvf/++/5cBQB/x8cff6zt27dr69atio6O1uzZs8/5uU899ZRKSkq0aNGiCzhC9DSEHViG2+3Wvffeq9/85jcKCgqSJB05ckS1tbUaP368JGnQoEGKiIjQ2rVrJbV9+quvr5cknThxQq2trYqLi/PPCgA4J4mJiZKkgIAAPfDAA/rkk0+UkJCgyspKnTx5UlLbB52ysjLvspL061//Wm+99ZbWrl2r3r17+2Xs8A/CDizj2Wef1ZgxYzRy5EhvLTo6WnFxcXrjjTcktZ3SKioq8p6vX7x4sVauXKn4+HjFx8dr1qxZGjFihD+GD+AcNDY26tixY97Hr776qkaMGKGYmBhdeeWV+tOf/iRJevPNN9W/f38NHDhQUtv+4dVXX9W6desUERHhh5HDn3r5ewBAd9i5c6fefPNNffzxx6e1vfPOO3r44Ye1aNEiXX755brmmmu85/VffPFF3XnnnXr00UdVU1OjsWPHKisrS9/73vcu9ioAOAfV1dWaMmWKXC6XPB6PUlNT9corr0iS/vu//1t33XWXnnrqKdntdi1btkySdPDgQf34xz9Wamqqxo4dK0kKCgrSpk2b/LYeuLgIO7CETz75RPv371daWpokqaqqSnPmzFFlZaXmzp3b6TqcoUOH6vLLL5ckLVmyRMXFxZKkmJgYTZo0SRs2bCDsAD1UamqqvvjiizO2DR48WHl5eafV+/fvL4/Hc6GHhh6M01iwhLlz56qyslL79+/X/v37NXr0aL300kve+im/+93vFBoaqhtuuEFS247zVBBqbGzU//7v/+qKK67wyzoAAC4Mwg4s76WXXtKgQYOUlpam9957T3/961+999t4+eWX9fvf/17Dhw/XqFGjNG7cOE2fPt3PIwYAdCfDw7E9OZ1OhYeHq76+Xna73d/DAQAA5+Bc3785sgMAACyNsAMAACzNr2Hn5z//uQzD6PQ3ZMgQb3tTU5PmzZunqKgohYWFacqUKaquru70GmVlZZo8ebJ69+6tmJgYPfTQQ96bSgEAAPj9q+eXX365PvroI+/jU/c/kaQHH3xQq1ev1sqVKxUeHq758+fr9ttv16effipJcrlcmjx5smJjY/XZZ5+psrJSs2bNUkBAgJ566qmLvi4AAKDn8XvY6dWrl2JjY0+r19fX6/e//71WrFjh/ZrwsmXLNHToUH3++ecaPXq0PvzwQ+3evVsfffSRHA6HMjMz9Ytf/EIPP/ywfv7znyswMPBirw4AAOhh/B529uzZo/j4eAUHBys7O1uLFi1SYmKiCgoK1Nra6v1NI0kaMmSIEhMTlZeXp9GjRysvL08ZGRlyOBzeZXJycjR37lzt2rXrrLf9b25uVnNzs/ex0+m8cCsI4B9C8iOr/T0EoMfa//Rkv/bv17Bz9dVXa/ny5Ro8eLAqKyu1cOFCffe739XOnTtVVVWlwMDA037DxOFwqKqqSlLbXXI7Bp1T7afazmbRokVauHDhafUtW7YoLCxMkpSZmamGhgbt3bvX2z5kyBDZbDbt2rXLW0tOTlZUVJQKCgo6jSEpKUmFhYVqaWmRJIWHh2vw4MH66quvvOEqKChIw4cP1/79+1VTU+N9flZWlqqrq1VWVuatZWRkqKWlRUVFRd7awIEDFRoaqm3btnlr/fv3V3x8vPLz8713DI2OjlZqaqp27Njh/bXvsLAwpaena8+ePTp69KgkyWazaeTIkTp48KAqKiq8rzlixAjV19dr37593trQoUNlGIZ2797daS769u2rrVu3emuxsbFKTEzUF198odbWVklSRESEBg0apC+//FINDQ2SpODgYA0bNkylpaWqra31Pv+qq65SZWWlysvLO81Fc3Oz987HkpSWlqaQkBBt377dW0tISFBcXJw2b97srZ3rXPTq1UtXXnmlysvLO92UcMSIETp27JhKS0s7zYUkffnll95aSkqKIiIiOt3pNS4uTgkJCdq6dav3urLIyEilpaVp9+7dOn78uCQpJCREGRkZ2rdvnw4fPvyNczFs2DCdOHFCe/bs8dYGDRqkoKAg7dix4xvnol+/fkpJSdH27dvV1NQkSerTp4+GDh2q4uJi7+8PBQQEaMSIESorK+u0XV155ZWqq6vz/s6YJKWnp8vj8XSai9TUVIWHh3eai/j4ePXv318FBQVyuVzfai4Mw1BWVpYqKip08OBB72sOHz5cjY2NKikp8dYGDx6swMDATnORmJgoh8Oh/Px8by0mJkbJycnatm2b94OQ3W7XkCFDVFRU5P2x2MDAQGVmZurAgQOdrh8cOXKkBoe7Ncbhu5PHOwdMBZrSxAS3t7ah0lTVCWl6qq/2xRFDXxwxNXOgSwHtV1HuazC0odLUzYkuRQe31Y40S+8csOm6WLcG2Nv6OemRXtljU2Zft66M9vX9+j5T/YKlG+J9/bx/0FSTS7o1yVfLqzFUVG/orjRfbfcxQ5/XmJqa4lJYQFvt0NeGPjhoKqe/W5f1buvneKv0RqlNo2PcSo/w9b18j6nB4R5lx/hqbx8wFWyTbuzv62d9hanaJmlah7nYethQYZ2pWWku9Wq7FZb2Og1trDJ1S5JLUW2/76vDTdK7ZTZdH+dWap+2flrd0h9LbBoR5daIKF/fr+0zFRsiXR/n62dtuakWt3RLh7n4tNrQXqehWR3mYtdRQ5tqTU1LdSm0/d3yYKOhDw+ZurG/S/HtvyXa0CqtLLUpO8atoR3mYlmxqaERHo3uMBdv7TcV2kvK6TAXuRWmjjRJUzvMRcFhQ9vqTN2V5pLZPhd7nIY+qTJ1W5JLke1zUdMkrSqz6YZ4t5LD2vppdkt/LrFpZLRbw/v6+l6x19RlodJ1sb5+Vpebcnuk7yf6an+rNlTaYGjmQF9tx1FD+bWm7hzgUoitrVZ23NBHFaYmJbgUG9JWq2+V3iy1aYzDrcHhne9scyH25R3fj79Jj7rPzrFjx5SUlKRnn31WISEhuvvuuzsdgZHadvhjx47Vr371K82ZM0cHDhzQBx984G3/+uuvFRoaqjVr1mjixIln7OdMR3YSEhIuyH12+LQHfDN/f+LrLmzrwNldqO38krzPzqlP/CUlJYqNjVVLS0unX7eV2n4E7tQ1PrGxsad9O+vU4zNdB3RKUFCQ7HZ7pz8AAGBNPSrsHD9+XHv37lVcXJxGjhypgIAA5ebmetuLiopUVlam7OxsSVJ2drZ27NjR6RTQunXrZLfblZ6eftHHDwAAeh6/XrPzk5/8RN///veVlJSkiooKPfHEE7LZbLrzzjsVHh6ue+65RwsWLFDfvn1lt9t1//33Kzs7W6NHj5YkTZgwQenp6Zo5c6aeeeYZVVVV6bHHHtO8efMUFBTkz1UDAAA9hF/DzsGDB3XnnXfqyJEj6tevn6655hp9/vnn6tevnyTpueeek2mamjJlipqbm5WTk6MXX3zR+3ybzaZVq1Zp7ty5ys7OVmhoqGbPnq0nn3zSX6sEAAB6GL+Gnddee+0b24ODg7VkyRItWbLkrMskJSVpzZo13T00AABgET3qmh0AAIDuRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACWRtgBAACW1mPCztNPPy3DMPTAAw94a01NTZo3b56ioqIUFhamKVOmqLq6utPzysrKNHnyZPXu3VsxMTF66KGHdPLkyYs8egAA0FP1iLCTn5+v//7v/9awYcM61R988EG99957WrlypTZu3KiKigrdfvvt3naXy6XJkyerpaVFn332mV5++WUtX75cjz/++MVeBQAA0EP5PewcP35cM2bM0O9+9ztFRkZ66/X19fr973+vZ599VjfccINGjhypZcuW6bPPPtPnn38uSfrwww+1e/du/elPf1JmZqYmTpyoX/ziF1qyZIlaWlr8tUoAAKAH8XvYmTdvniZPnqzx48d3qhcUFKi1tbVTfciQIUpMTFReXp4kKS8vTxkZGXI4HN5lcnJy5HQ6tWvXrrP22dzcLKfT2ekPAABYUy9/dv7aa69p69atys/PP62tqqpKgYGBioiI6FR3OByqqqryLtMx6JxqP9V2NosWLdLChQtPq2/ZskVhYWGSpMzMTDU0NGjv3r3e9iFDhshms3UKUsnJyYqKilJBQUGnMSQlJamwsFD/PMglSTrYaOjDQ6Zu7O9SfO+25RpapZWlNmXHuDU0wuN9/rJiU0MjPBod46u9td9UaC8pp7/bW8utMHWkSZqa6qsVHDa0rc7UXWkumUZbbY/T0CdVpm5LcikyqK1W0yStKrPphni3ksPa+ml2S38usWlktFvD+/r6XrHX1GWh0nWxvn5Wl5tye6TvJ/pqf6s2VNpgaOZAX23HUUP5tabuHOBSiK2tVnbc0EcVpiYluBQb0larb5XeLLVpjMOtweG+vv9QbNMVkW5d1c9Xe3O/qT4B0oTLfP18dMjUsRbpjhRfLb/W0I6jpu4e5FL7VKi43tDfqk3dnuxSRGBbrfqEtLrcpnHxbiW1z0WTS1qx16ZR0W4N6zAXfy4xlRDm0bWxvtqqsrbPDDd1mIuPqwyVHzc0o8NcbK8ztOWwqR8McCm4fS4OHDeUW2FqcoJLjva5ONYivbXfpmscbg1qnwuPpGXFNmVEupXVYS7+UmoqIlAa32EuPjxkqqFVmpLsq22uNbTzqOn99yhJRfWGPq02NSXFpfCAtlrVCWlNuU3j491KbJ+LEy7p1b02ZfVzKyPS1/cfS0yl9PHoGoev9l6ZKdOQJif4+t5YZepQo/SDAb7atjpDBYdNzRjo0ubNmyVJkZGRSktL0+7du3X8+HFJUkhIiDIyMrRv3z4dPnxYkmQYhrKyslRRUaGDBw96X3P48OFqbGxUSUmJtzZ48GAFBgZqx44d3lpiYqIcDken/U5MTIySk5O1bds2NTc3S5LsdruGDBmioqIi1dfXS5ICAwOVmZmpAwcOdLp+cOTIkRoc7taYDnPxzgFTgaY0scNcbKg0VXVCmt5hm/3iiKEvjpiaOdClgPaPn/saDG2oNHVzokvRwW21I83SOwdsui7WrQH2tn5OeqRX9tiU2detK6N9fb++z1S/YOmGeF8/7x801eSSbk3y1fJqDBXVG7orzVfbfczQ5zWmpqa4FNb+7+LQ14Y+OGgqp79bl/Vu6+d4q/RGqU2jY9xK77D/Wr7H1OBwj7I77L/ePmAq2Cbd2GH/tb7CVG2TNK3DXGw9bKiwztSsNJd6tW+0e52GNlaZuiXJpaj2/dfhJundMpuuj3MrtU9bP61u6Y8lNo2IcmtElK/v1/aZig2Rro/z9bO23FSLW7qlw1x8Wm1or9PQrA5zseuooU21pqaluhTa/m7Jvrxr+3JJqqysVHl5ufdxRkaGmpubVVxc7K2lpaUpJCRE27dv99YSEhIUFxfn3VdIUnR0tFJTU7/xwEZHhsfj8fz9xbpfeXm5Ro0apXXr1nmv1bn++uuVmZmpxYsXa8WKFbr77ru9O55TrrrqKo0dO1a/+tWvNGfOHB04cEAffPCBt/3rr79WaGio1qxZo4kTJ56x7+bm5k6v63Q6lZCQoPr6etnt9m5dz+RHVnfr6wFWs//pyf4eQrdgWwfO7kJt506nU+Hh4X/3/dtvp7EKCgpUU1OjK6+8Ur169VKvXr20ceNGvfDCC+rVq5ccDodaWlp07NixTs+rrq5WbGysJCk2Nva0b2edenxqmTMJCgqS3W7v9AcAAKzJb2Fn3Lhx2rFjhwoLC71/o0aN0owZM7z/HRAQoNzcXO9zioqKVFZWpuzsbElSdna2duzYoZqaGu8y69atk91uV3p6+kVfJwAA0PP47ZqdPn366IorruhUCw0NVVRUlLd+zz33aMGCBerbt6/sdrvuv/9+ZWdna/To0ZKkCRMmKD09XTNnztQzzzyjqqoqPfbYY5o3b56CgoIu+joBAICex68XKP89zz33nEzT1JQpU9Tc3KycnBy9+OKL3nabzaZVq1Zp7ty5ys7OVmhoqGbPnq0nn3zSj6MGAAA9SY8KOxs2bOj0ODg4WEuWLNGSJUvO+pykpCStWbPmAo8MAABcqvx+nx0AAIALibADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsjbADAAAsrUthZ+vWrdqxY4f38TvvvKNbb71V//Zv/6aWlpZuGxwAAMD56lLY+dGPfqTi4mJJ0r59+zR9+nT17t1bK1eu1E9/+tNuHSAAAMD56FLYKS4uVmZmpiRp5cqVuvbaa7VixQotX75cb775ZneODwAA4Lx0Kex4PB653W5J0kcffaRJkyZJkhISEnT48OHuGx0AAMB56lLYGTVqlH75y1/qj3/8ozZu3KjJkydLkkpLS+VwOLp1gAAAAOejS2Hnueee09atWzV//nz9+7//uwYOHChJ+stf/qLvfOc73TpAAACA89GrK08aPnx4p29jnfIf//Ef6tWrSy8JAABwQXTpyE5qaqqOHDlyWr2pqUmDBg0670EBAAB0ly6Fnf3798vlcp1Wb25u1sGDB897UAAAAN3lW51zevfdd73//cEHHyg8PNz72OVyKTc3VykpKd03OgAAgPP0rcLOrbfeKkkyDEOzZ8/u1BYQEKDk5GT953/+Z7cNDgAA4Hx9q7Bz6t46KSkpys/PV3R09AUZFAAAQHfp0lenSktLu3scAAAAF0SXvyeem5ur3Nxc1dTUeI/4nPKHP/zhvAcGAADQHboUdhYuXKgnn3xSo0aNUlxcnAzD6O5xAQAAdIsuhZ2lS5dq+fLlmjlzZnePBwAAoFt16T47LS0t/CwEAAC4JHQp7Nx7771asWJFd48FAACg23Up7DQ1NenZZ5/Vddddp/vvv18LFizo9Heufvvb32rYsGGy2+2y2+3Kzs7W2rVrO/Uzb948RUVFKSwsTFOmTFF1dXWn1ygrK9PkyZPVu3dvxcTE6KGHHtLJkye7sloAAMCCunTNzvbt25WZmSlJ2rlzZ6e2b3Oxcv/+/fX0008rLS1NHo9HL7/8sm655RZ98cUXuvzyy/Xggw9q9erVWrlypcLDwzV//nzdfvvt+vTTTyW13bV58uTJio2N1WeffabKykrNmjVLAQEBeuqpp7qyagAAwGIMj8fj8fcgOurbt6/+4z/+Q3fccYf69eunFStW6I477pAkffXVVxo6dKjy8vI0evRorV27VjfddJMqKirkcDgktV08/fDDD6u2tlaBgYHn1KfT6VR4eLjq6+tlt9u7dX2SH1ndra8HWM3+pyf7ewjdgm0dOLsLtZ2f6/t3l05jXQgul0uvvfaaGhsblZ2drYKCArW2tmr8+PHeZYYMGaLExETl5eVJkvLy8pSRkeENOpKUk5Mjp9OpXbt2nbWv5uZmOZ3OTn8AAMCaunQaa+zYsd94umr9+vXn/Fo7duxQdna2mpqaFBYWpr/+9a9KT09XYWGhAgMDFRER0Wl5h8OhqqoqSVJVVVWnoHOq/VTb2SxatEgLFy48rb5lyxaFhYVJkjIzM9XQ0KC9e/d624cMGSKbzdYpSCUnJysqKkoFBQWdxpCUlKTCwkL986C2X4c/2Gjow0OmbuzvUnzvtuUaWqWVpTZlx7g1NMJ3gG1ZsamhER6NjvHV3tpvKrSXlNPfdwPH3ApTR5qkqam+WsFhQ9vqTN2V5pLZ/r9oj9PQJ1WmbktyKTKorVbTJK0qs+mGeLeSw9r6aXZLfy6xaWS0W8P7+vpesdfUZaHSdbG+flaXm3J7pO8n+mp/qzZU2mBo5kBfbcdRQ/m1pu4c4FKIra1WdtzQRxWmJiW4FBvSVqtvld4stWmMw63B4b6+/1Bs0xWRbl3Vz1d7c7+pPgHShMt8/Xx0yNSxFumOFF8tv9bQjqOm7h7k0ql/rcX1hv5Wber2ZJci2g/8VZ+QVpfbNC7eraT2uWhySSv22jQq2q1hHebizyWmEsI8ujbWV1tV1vaZ4aYOc/FxlaHy44ZmdJiL7XWGthw29YMBLgW3z8WB44ZyK0xNTnDJ0T4Xx1qkt/bbdI3DrUHtc+GRtKzYpoxIt7I6zMVfSk1FBErjO8zFh4dMNbRKU5J9tc21hnYeNb3/HiWpqN7Qp9WmpqS4FB7QVqs6Ia0pt2l8vFuJ7XNxwiW9utemrH5uZUT6+v5jiamUPh5d4/DV3iszZRrS5ARf3xurTB1qlH4wwFfbVmeo4LCpGQNd2rx5syQpMjJSaWlp2r17t44fPy5JCgkJUUZGhvbt26fDhw9LajtVnpWVpYqKCh08eND7msOHD1djY6NKSkq8tcGDByswMFA7duzw1hITE+VwOJSfn++txcTEKDk5Wdu2bVNzc7MkyW63a8iQISoqKlJ9fb0kKTAwUJmZmTpw4ECn6wdHjhypweFujekwF+8cMBVoShM7zMWGSlNVJ6TpHbbZL44Y+uKIqZkDXQpo//i5r8HQhkpTNye6FB3cVjvSLL1zwKbrYt0aYG/r56RHemWPTZl93boy2tf36/tM9QuWboj39fP+QVNNLunWJF8tr8ZQUb2hu9J8td3HDH1eY2pqikth7f8uDn1t6IODpnL6u3VZ77Z+jrdKb5TaNDrGrfQO+6/le0wNDvcou8P+6+0DpoJt0o0d9l/rK0zVNknTOszF1sOGCutMzUpzqVf7RrvXaWhjlalbklyKat9/HW6S3i2z6fo4t1L7tPXT6pb+WGLTiCi3RkT5+n5tn6nYEOn6OF8/a8tNtbilWzrMxafVhvY6Dc3qMBe7jhraVGtqWqpLoe3vluzLu7Yvl6TKykqVl5d7H2dkZKi5uVnFxcXeWlpamkJCQrR9+3ZvLSEhQXFxcd59hSRFR0crNTX1Gw9sdNSl01gPPvhgp8etra0qLCzUzp07NXv2bD3//PPn/FotLS0qKytTfX29/vKXv+h//ud/tHHjRhUWFuruu+/27nhOueqqqzR27Fj96le/0pw5c3TgwAF98MEH3vavv/5aoaGhWrNmjSZOnHjGPpubmzu9rtPpVEJCAqexAD/gNBZgff4+jdWlIzvPPffcGes///nPvZ/IzlVgYKAGDhwoqe3TUX5+vp5//nlNmzZNLS0tOnbsWKejO9XV1YqNjZUkxcbGdkp6p9pPtZ1NUFCQgoKCvtU4AQDApalbr9n54Q9/eN6/i+V2u9Xc3KyRI0cqICBAubm53raioiKVlZUpOztbkpSdna0dO3aopqbGu8y6detkt9uVnp5+XuMAAADW0OUfAj2TvLw8BQcHn/Pyjz76qCZOnKjExEQ1NDRoxYoV2rBhgz744AOFh4frnnvu0YIFC9S3b1/Z7Xbdf//9ys7O1ujRoyVJEyZMUHp6umbOnKlnnnlGVVVVeuyxxzRv3jyO3AAAAEldDDu33357p8cej0eVlZXasmWLfvazn53z69TU1GjWrFmqrKxUeHi4hg0bpg8++EDf+973JLWdLjNNU1OmTFFzc7NycnL04osvep9vs9m0atUqzZ07V9nZ2QoNDdXs2bP15JNPdmW1AACABXXpAuW7776702PTNNWvXz/dcMMNmjBhQrcN7mLhPjuA/3CBMmB9l+QFysuWLevywAAAAC6m87pmp6CgQF9++aUk6fLLL9eIESO6ZVAAAADdpUthp6amRtOnT9eGDRu8Xws/duyYxo4dq9dee039+vXrzjECAAB0WZe+en7//feroaFBu3btUl1dnerq6rRz5045nU79y7/8S3ePEQAAoMu6dGTn/fff10cffaShQ4d6a+np6VqyZMkleYEyAACwri4d2XG73QoICDitHhAQILfbfYZnAAAA+EeXws4NN9ygf/3Xf1VFRYW3dujQIT344IMaN25ctw0OAADgfHUp7PzXf/2XnE6nkpOTNWDAAA0YMEApKSlyOp36zW9+091jBAAA6LIuXbOTkJCgrVu36qOPPtJXX30lSRo6dKjGjx/frYMDAAA4X9/qyM769euVnp4up9MpwzD0ve99T/fff7/uv/9+ZWVl6fLLL9cnn3xyocYKAADwrX2rsLN48WLdd999Z7wlc3h4uH70ox/p2Wef7bbBAQAAnK9vFXa2bdumG2+88aztEyZMUEFBwXkPCgAAoLt8q7BTXV19xq+cn9KrVy/V1tae96AAAAC6y7cKO5dddpl27tx51vbt27crLi7uvAcFAADQXb5V2Jk0aZJ+9rOfqamp6bS2EydO6IknntBNN93UbYMDAAA4X9/qq+ePPfaY3nrrLQ0aNEjz58/X4MGDJUlfffWVlixZIpfLpX//93+/IAMFAADoim8VdhwOhz777DPNnTtXjz76qDwejyTJMAzl5ORoyZIlcjgcF2SgAAAAXfGtbyqYlJSkNWvW6OjRoyopKZHH41FaWpoiIyMvxPgAAADOS5fuoCxJkZGRysrK6s6xAAAAdLsu/TYWAADApYKwAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALI2wAwAALM2vYWfRokXKyspSnz59FBMTo1tvvVVFRUWdlmlqatK8efMUFRWlsLAwTZkyRdXV1Z2WKSsr0+TJk9W7d2/FxMTooYce0smTJy/mqgAAgB7Kr2Fn48aNmjdvnj7//HOtW7dOra2tmjBhghobG73LPPjgg3rvvfe0cuVKbdy4URUVFbr99tu97S6XS5MnT1ZLS4s+++wzvfzyy1q+fLkef/xxf6wSAADoYQyPx+Px9yBOqa2tVUxMjDZu3Khrr71W9fX16tevn1asWKE77rhDkvTVV19p6NChysvL0+jRo7V27VrddNNNqqiokMPhkCQtXbpUDz/8sGpraxUYGPh3+3U6nQoPD1d9fb3sdnu3rlPyI6u79fUAq9n/9GR/D6FbsK0DZ3ehtvNzff/uUdfs1NfXS5L69u0rSSooKFBra6vGjx/vXWbIkCFKTExUXl6eJCkvL08ZGRneoCNJOTk5cjqd2rVr10UcPQAA6Il6+XsAp7jdbj3wwAMaM2aMrrjiCklSVVWVAgMDFRER0WlZh8Ohqqoq7zIdg86p9lNtZ9Lc3Kzm5mbvY6fT2V2rAQAAepgeE3bmzZunnTt36m9/+9sF72vRokVauHDhafUtW7YoLCxMkpSZmamGhgbt3bvX2z5kyBDZbLZOR4ySk5MVFRWlgoICb83hcCgpKUmFhYX650EuSdLBRkMfHjJ1Y3+X4nu3LdfQKq0stSk7xq2hEb6zicuKTQ2N8Gh0jK/21n5Tob2knP5uby23wtSRJmlqqq9WcNjQtjpTd6W5ZBpttT1OQ59UmbotyaXIoLZaTZO0qsymG+LdSg5r66fZLf25xKaR0W4N7+vre8VeU5eFStfF+vpZXW7K7ZG+n+ir/a3aUGmDoZkDfbUdRw3l15q6c4BLIba2WtlxQx9VmJqU4FJsSFutvlV6s9SmMQ63Bof7+v5DsU1XRLp1VT9f7c39pvoESBMu8/Xz0SFTx1qkO1J8tfxaQzuOmrp7kEvtU6HiekN/qzZ1e7JLEe1nOKtPSKvLbRoX71ZS+1w0uaQVe20aFe3WsA5z8ecSUwlhHl0b66utKms7QHpTh7n4uMpQ+XFDMzrMxfY6Q1sOm/rBAJeC2+fiwHFDuRWmJie45Gifi2Mt0lv7bbrG4dag9rnwSFpWbFNGpFtZHebiL6WmIgKl8R3m4sNDphpapSnJvtrmWkM7j5ref4+SVFRv6NNqU1NSXAoPaKtVnZDWlNs0Pt6txPa5OOGSXt1rU1Y/tzIifX3/scRUSh+PrnH4au+VmTINaXKCr++NVaYONUo/GOCrbaszVHDY1IyBLm3evFmSFBkZqbS0NO3evVvHjx+XJIWEhCgjI0P79u3T4cOHJUmGYSgrK0sVFRU6ePCg9zWHDx+uxsZGlZSUeGuDBw9WYGCgduzY4a0lJibK4XAoPz/fW4uJiVFycrK2bdvm/SBkt9s1ZMgQFRUVeY86BwYGKjMzUwcOHOj0RYmRI0dqcLhbYzrMxTsHTAWa0sQOc7Gh0lTVCWl6h232iyOGvjhiauZAlwLaj7XvazC0odLUzYkuRQe31Y40S+8csOm6WLcG2Nv6OemRXtljU2Zft66M9vX9+j5T/YKlG+J9/bx/0FSTS7o1yVfLqzFUVG/orjRfbfcxQ5/XmJqa4lJY+7+LQ18b+uCgqZz+bl3Wu62f463SG6U2jY5xK73D/mv5HlODwz3K7rD/evuAqWCbdGOH/df6ClO1TdK0DnOx9bChwjpTs9Jc6tW+0e51GtpYZeqWJJei2vdfh5ukd8tsuj7OrdQ+bf20uqU/ltg0IsqtEVG+vl/bZyo2RLo+ztfP2nJTLW7plg5z8Wm1ob1OQ7M6zMWuo4Y21ZqalupSaPu7Jfvyru3LJamyslLl5eXexxkZGWpublZxcbG3lpaWppCQEG3fvt1bS0hIUFxcnHdfIUnR0dFKTU095zM4PeKanfnz5+udd97Rxx9/rJSUFG99/fr1GjdunI4ePdrp6E5SUpIeeOABPfjgg3r88cf17rvvqrCw0NteWlqq1NRUbd26VSNGjDitvzMd2UlISOCaHcAPuGYHsL5/6Gt2PB6P5s+fr7/+9a9av359p6AjtX1aCggIUG5urrdWVFSksrIyZWdnS5Kys7O1Y8cO1dTUeJdZt26d7Ha70tPTz9hvUFCQ7HZ7pz8AAGBNfj2NNW/ePK1YsULvvPOO+vTp473GJjw8XCEhIQoPD9c999yjBQsWqG/fvrLb7br//vuVnZ2t0aNHS5ImTJig9PR0zZw5U88884yqqqr02GOPad68eQoKCvLn6gEAgB7Ar2Hnt7/9rSTp+uuv71RftmyZ7rrrLknSc889J9M0NWXKFDU3NysnJ0cvvviid1mbzaZVq1Zp7ty5ys7OVmhoqGbPnq0nn3zyYq0GAADowfwads7lcqHg4GAtWbJES5YsOesySUlJWrNmTXcODQAAWESPus8OAABAdyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAASyPsAAAAS/Nr2Pn444/1/e9/X/Hx8TIMQ2+//Xando/Ho8cff1xxcXEKCQnR+PHjtWfPnk7L1NXVacaMGbLb7YqIiNA999yj48ePX8S1AAAAPZlfw05jY6OGDx+uJUuWnLH9mWee0QsvvKClS5dq06ZNCg0NVU5OjpqamrzLzJgxQ7t27dK6deu0atUqffzxx5ozZ87FWgUAANDD9fJn5xMnTtTEiRPP2ObxeLR48WI99thjuuWWWyRJr7zyihwOh95++21Nnz5dX375pd5//33l5+dr1KhRkqTf/OY3mjRpkn79618rPj7+oq0LAADomXrsNTulpaWqqqrS+PHjvbXw8HBdffXVysvLkyTl5eUpIiLCG3Qkafz48TJNU5s2bTrrazc3N8vpdHb6AwAA1uTXIzvfpKqqSpLkcDg61R0Oh7etqqpKMTExndp79eqlvn37epc5k0WLFmnhwoWn1bds2aKwsDBJUmZmphoaGrR3715v+5AhQ2Sz2bRr1y5vLTk5WVFRUSooKOg0xqSkJBUWFuqfB7kkSQcbDX14yNSN/V2K7922XEOrtLLUpuwYt4ZGeLzPX1ZsamiER6NjfLW39psK7SXl9Hd7a7kVpo40SVNTfbWCw4a21Zm6K80l02ir7XEa+qTK1G1JLkUGtdVqmqRVZTbdEO9WclhbP81u6c8lNo2Mdmt4X1/fK/aauixUui7W18/qclNuj/T9RF/tb9WGShsMzRzoq+04aii/1tSdA1wKsbXVyo4b+qjC1KQEl2JD2mr1rdKbpTaNcbg1ONzX9x+Kbboi0q2r+vlqb+431SdAmnCZr5+PDpk61iLdkeKr5dca2nHU1N2DXGqfChXXG/pbtanbk12KCGyrVZ+QVpfbNC7eraT2uWhySSv22jQq2q1hHebizyWmEsI8ujbWV1tV1vaZ4aYOc/FxlaHy44ZmdJiL7XWGthw29YMBLgW3z8WB44ZyK0xNTnDJ0T4Xx1qkt/bbdI3DrUHtc+GRtKzYpoxIt7I6zMVfSk1FBErjO8zFh4dMNbRKU5J9tc21hnYeNb3/HiWpqN7Qp9WmpqS4FB7QVqs6Ia0pt2l8vFuJ7XNxwiW9utemrH5uZUT6+v5jiamUPh5d4/DV3iszZRrS5ARf3xurTB1qlH4wwFfbVmeo4LCpGQNd2rx5syQpMjJSaWlp2r17t/e6u5CQEGVkZGjfvn06fPiwJMkwDGVlZamiokIHDx70vubw4cPV2NiokpISb23w4MEKDAzUjh07vLXExEQ5HA7l5+d7azExMUpOTta2bdvU3NwsSbLb7RoyZIiKiopUX18vSQoMDFRmZqYOHDig6upq7/NHjhypweFujekwF+8cMBVoShM7zMWGSlNVJ6TpHbbZL44Y+uKIqZkDXQpo//i5r8HQhkpTNye6FB3cVjvSLL1zwKbrYt0aYG/r56RHemWPTZl93boy2tf36/tM9QuWboj39fP+QVNNLunWJF8tr8ZQUb2hu9J8td3HDH1eY2pqikth7f8uDn1t6IODpnL6u3VZ77Z+jrdKb5TaNDrGrfQO+6/le0wNDvcou8P+6+0DpoJt0o0d9l/rK0zVNknTOszF1sOGCutMzUpzqVf7RrvXaWhjlalbklyKat9/HW6S3i2z6fo4t1L7tPXT6pb+WGLTiCi3RkT5+n5tn6nYEOn6OF8/a8tNtbilWzrMxafVhvY6Dc3qMBe7jhraVGtqWqpLoe3vluzLu7Yvl6TKykqVl5d7H2dkZKi5uVnFxcXeWlpamkJCQrR9+3ZvLSEhQXFxcd59hSRFR0crNTW10/vxNzE8Ho/n7y924RmGob/+9a+69dZbJUmfffaZxowZo4qKCsXFxXmXmzp1qgzD0Ouvv66nnnpKL7/8soqKijq9VkxMjBYuXKi5c+eesa/m5mbvDk2SnE6nEhISVF9fL7vd3q3rlfzI6m59PcBq9j892d9D6BZs68DZXajt3Ol0Kjw8/O++f/fY01ixsbGS1OnT06nHp9piY2NVU1PTqf3kyZOqq6vzLnMmQUFBstvtnf4AAIA19diwk5KSotjYWOXm5nprTqdTmzZtUnZ2tiQpOztbx44d63QKaf369XK73br66qsv+pgBAEDP49drdo4fP97p/HppaakKCwvVt29fJSYm6oEHHtAvf/lLpaWlKSUlRT/72c8UHx/vPdU1dOhQ3Xjjjbrvvvu0dOlStba2av78+Zo+fTrfxAIAAJL8HHa2bNmisWPHeh8vWLBAkjR79mwtX75cP/3pT9XY2Kg5c+bo2LFjuuaaa/T+++8rODjY+5w///nPmj9/vsaNGyfTNDVlyhS98MILF31dAABAz9RjLlD2p3O9wKkruGgR+GZcoAxYHxcoAwAAXECEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmEHQAAYGmWCTtLlixRcnKygoODdfXVV2vz5s3+HhIAAOgBLBF2Xn/9dS1YsEBPPPGEtm7dquHDhysnJ0c1NTX+HhoAAPAzS4SdZ599Vvfdd5/uvvtupaena+nSperdu7f+8Ic/+HtoAADAz3r5ewDnq6WlRQUFBXr00Ue9NdM0NX78eOXl5Z3xOc3NzWpubvY+rq+vlyQ5nc5uH5+7+etuf03ASi7EducPbOvA2V2o7fzU63o8nm9c7pIPO4cPH5bL5ZLD4ehUdzgc+uqrr874nEWLFmnhwoWn1RMSEi7IGAGcXfhif48AwIV2obfzhoYGhYeHn7X9kg87XfHoo49qwYIF3sdut1t1dXWKioqSYRh+HBkuJKfTqYSEBJWXl8tut/t7OAAuELb1fxwej0cNDQ2Kj4//xuUu+bATHR0tm82m6urqTvXq6mrFxsae8TlBQUEKCgrqVIuIiLhQQ0QPY7fb2QEC/wDY1v8xfNMRnVMu+QuUAwMDNXLkSOXm5nprbrdbubm5ys7O9uPIAABAT3DJH9mRpAULFmj27NkaNWqUrrrqKi1evFiNjY26++67/T00AADgZ5YIO9OmTVNtba0ef/xxVVVVKTMzU++///5pFy3jH1tQUJCeeOKJ005hArAWtnX8/wzP3/u+FgAAwCXskr9mBwAA4JsQdgAAgKURdgAAgKURdgAAgKURdgAAgKURdvAPiy8iAsA/BkvcZwc4F5WVlSovL9fRo0c1fvx42Ww2fw8JAHAREHbwD2H79u26+eabFRQUpOrqasXFxenxxx9XTk6O+vbt6+/hAegmNTU1CgwM5PcO0QmnsWB5tbW1mjZtmmbMmKG1a9dq9+7dGj58uH7xi1/ohRdeUG1trb+HCKAbfPnll0pISNB9990np9Pp7+GgByHswPJqa2vV1NSk22+/XampqYqPj9drr72mm2++WW+99ZaWL1+ur7/+2t/DBHAeqqurde+99+qaa67Rhg0bdO+99xJ44EXYgeW1tLSotbXVG2hOnDghSXr66ac1duxY/fa3v1VJSYkkLloGLlVffPGFkpOT9atf/UqrV69Wbm4ugQde/DYWLMntdsvj8XgvQv7ud78r0zS1ceNGSVJzc7P3RwKzsrI0cOBAvfrqq34bL4DzU1tbq127dun666+XJH3++eeaPHmyxo0bp9/97ncKDw+X1PaBxjAMP44U/sCRHVjO7t27NWvWLOXk5Oi+++7Txo0b9fzzz+vQoUOaOnWqpLZfRT558qQk6dprr1VjY6M/hwygC1wul/e/+/Xr5w06brdbo0eP1po1a5Sbm+u9hqe1tVVLly7VunXr/DRi+AthB5ZSVFSk73znO3K5XMrKylJ+fr4eeugh/c///I9+8YtfqKCgQLfddptaW1tlmm3//GtqahQaGqqTJ09yGgu4RBQXF2vx4sWqrKw8re3Utn311Vdr7dq13sDzox/9SP/6r/+q1NTUiz1c+BmnsWAZHo9Hjz32mEpKSvT6669LkhoaGrR48WKtWrVKAwcO1NSpU/XTn/5UkpSenq7AwECtXr1an3/+ua644gp/Dh/AOSopKdHVV1+to0eP6pFHHtGCBQsUHR191uU//fRTffe731VkZKTWrVunK6+88iKOFj0B99mBZRiGoYqKClVVVXlrffr00QMPPKCQkBC99dZbKi4u1pYtW/R//+//1ZEjRxQcHKzNmzcrPT3djyMHcK4aGxu1aNEi3XzzzcrKytL8+fN18uRJ/fSnPz1j4GlpadGf/vQnhYWF6ZNPPmFb/wdF2IElnLro8Morr9SePXtUVFSkwYMHS2oLPPfcc4+Kior05ptv6ic/+YmefvppSW3n9k8d8gbQ85mmqZEjRyoqKkrTpk1TdHS0pk+fLklnDDzbtm3TJ598otzcXILOPzBOY8FS9u7dq9GjR+vmm2/W888/r7CwMG8QKi8vV1JSklatWqVJkyZJ4psZwKWosbFRoaGh3sevv/667rzzTv34xz/WI488oqioKLndbh06dEgJCQk6evSoIiMj/Thi+BtHdmApAwYM0BtvvKGJEycqJCREP//5z72f9AICAjRs2LBOOz2CDnDpORV0XC6XTNPUtGnT5PF49IMf/ECGYeiBBx7Qr3/9a5WWlmrFihUEHRB2YD1jx47VypUr9U//9E+qrKzU1KlTNWzYML3yyiuqqalRQkKCv4cIoBvYbDZ5PB653W5Nnz5dhmFo5syZevfdd7V3715t3rxZISEh/h4megBOY8Gytm7dqgULFmj//v3q1auXbDabXnvtNY0YMcLfQwPQjU69jRmGoXHjxqmwsFAbNmxQRkaGn0eGnoKwA0tzOp2qq6tTQ0OD4uLivvHrqQAuXS6XSw899JAWL16swsJCDRs2zN9DQg/CaSxYmt1ul91u9/cwAFwEl19+ubZu3UrQwWk4sgMAsAS+XYmz4QYjAABLIOjgbAg7AADA0gg7AADA0gg7AADA0gg7AADA0gg7AADA0gg7AADA0gg7AADA0gg7AADA0gg7AADA0gg7AADA0v4fPdy5c6ifWhAAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "circ.measure([0,1],[1,0])\n",
+    "circ.measure([0, 1], [1, 0])\n",
     "# The first argument specifies the list of qubits that we are measuring,\n",
     "# The second argument specifies the list of output bits (created earlier) in which we will store the outcomes,\n",
     "# Notice that we have reversed the second list: this is because by convention qiskit orders the classical bits in reverse relative to the qubits.\n",
     "# We recommend always reversing the list of classical bits, so that the qubits and classical output bits are ordered in the same way.\n",
     "\n",
-    "# Import Aer and execute\n",
-    "from qiskit import Aer, execute\n",
-    "\n",
-    "backend_sim = Aer.get_backend('qasm_simulator')\n",
-    "\n",
     "# We go ahead and execute the circuit with the function execute.\n",
-    "sim = execute(circ, backend_sim, shots=1000)\n",
+    "sim = backend_sim.run(circ, shots=1000)\n",
     "# Recall that shots specifies how many times the quantum circuit is run.\n",
     "\n",
     "# The results from the execution are stored in 'sim' and can be obtained using\n",
@@ -300,7 +443,6 @@
     "print(counts)\n",
     "\n",
     "# We plot the outcomes stored in the variable 'counts':\n",
-    "from qiskit.visualization import plot_histogram\n",
     "plot_histogram(counts)"
    ]
   },
@@ -331,24 +473,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before proceeding, there is one line that you need to run in order to be able to run quantum jobs within the qBraid-SDK environment:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "! qbraid jobs enable qbraid_sdk"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "<h2 style=\"color:MediumSeaGreen;\">Getting information about available quantum devices</h2>"
    ]
   },
@@ -365,17 +489,141 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There is a chance you might get the error \"No module named qbraid\" when running the cell below. If you do, just switch your kernel back to Python3[Default] momentarily, and then switch back to Python3[qBraid-SDK]. This should fix the issue."
+    "There is a chance you might get the error \"No module named qbraid\" when running the cell below. If you do, just switch your kernel back to `Python 3 [Default]` momentarily, and then switch back to `Python 3 [qBraid]`. This should fix the issue."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<h3>Supported Devices</h3><table><tr>\n",
+       "    <th style='text-align:left'>Provider</th>\n",
+       "    <th style='text-align:left'>Name</th>\n",
+       "    <th style='text-align:left'>qBraid ID</th>\n",
+       "    <th style='text-align:left'>Status</th></tr>\n",
+       "    <tr>\n",
+       "        <td style='text-align:left'>AWS</td>\n",
+       "        <td style='text-align:left'>DM1</td>\n",
+       "        <td style='text-align:left'><code>aws_dm_sim</code></td>\n",
+       "        <td><span style='color:green'>●</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>AWS</td>\n",
+       "        <td style='text-align:left'>SV1</td>\n",
+       "        <td style='text-align:left'><code>aws_sv_sim</code></td>\n",
+       "        <td><span style='color:green'>●</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>AWS</td>\n",
+       "        <td style='text-align:left'>TN1</td>\n",
+       "        <td style='text-align:left'><code>aws_tn_sim</code></td>\n",
+       "        <td><span style='color:green'>●</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>IBM</td>\n",
+       "        <td style='text-align:left'>Brisbane</td>\n",
+       "        <td style='text-align:left'><code>ibm_q_brisbane</code></td>\n",
+       "        <td><span style='color:green'>●</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>IBM</td>\n",
+       "        <td style='text-align:left'>Ext. stabilizer simulator</td>\n",
+       "        <td style='text-align:left'><code>ibm_q_simulator_extended_stabilizer</code></td>\n",
+       "        <td><span style='color:green'>●</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>IBM</td>\n",
+       "        <td style='text-align:left'>Kyoto</td>\n",
+       "        <td style='text-align:left'><code>ibm_q_kyoto</code></td>\n",
+       "        <td><span style='color:green'>●</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>IBM</td>\n",
+       "        <td style='text-align:left'>MPS simulator</td>\n",
+       "        <td style='text-align:left'><code>ibm_q_simulator_mps</code></td>\n",
+       "        <td><span style='color:green'>●</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>IBM</td>\n",
+       "        <td style='text-align:left'>Osaka</td>\n",
+       "        <td style='text-align:left'><code>ibm_q_osaka</code></td>\n",
+       "        <td><span style='color:green'>●</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>IBM</td>\n",
+       "        <td style='text-align:left'>Oslo</td>\n",
+       "        <td style='text-align:left'><code>ibm_q_oslo</code></td>\n",
+       "        <td><span style='color:red'>○</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>IBM</td>\n",
+       "        <td style='text-align:left'>QASM simulator</td>\n",
+       "        <td style='text-align:left'><code>ibm_q_qasm_simulator</code></td>\n",
+       "        <td><span style='color:green'>●</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>IBM</td>\n",
+       "        <td style='text-align:left'>Sherbrooke</td>\n",
+       "        <td style='text-align:left'><code>ibm_q_sherbrooke</code></td>\n",
+       "        <td><span style='color:green'>●</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>IBM</td>\n",
+       "        <td style='text-align:left'>Stabilizer simulator</td>\n",
+       "        <td style='text-align:left'><code>ibm_q_simulator_stabilizer</code></td>\n",
+       "        <td><span style='color:green'>●</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>IBM</td>\n",
+       "        <td style='text-align:left'>State vector simulator</td>\n",
+       "        <td style='text-align:left'><code>ibm_q_simulator_statevector</code></td>\n",
+       "        <td><span style='color:green'>●</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>IonQ</td>\n",
+       "        <td style='text-align:left'>Aria-1</td>\n",
+       "        <td style='text-align:left'><code>aws_ionq_aria1</code></td>\n",
+       "        <td><span style='color:red'>○</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>IonQ</td>\n",
+       "        <td style='text-align:left'>Aria-2</td>\n",
+       "        <td style='text-align:left'><code>aws_ionq_aria2</code></td>\n",
+       "        <td><span style='color:red'>○</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>IonQ</td>\n",
+       "        <td style='text-align:left'>Forte-1</td>\n",
+       "        <td style='text-align:left'><code>aws_ionq_forte1</code></td>\n",
+       "        <td><span style='color:green'>●</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>IonQ</td>\n",
+       "        <td style='text-align:left'>Harmony</td>\n",
+       "        <td style='text-align:left'><code>aws_ionq_harmony</code></td>\n",
+       "        <td><span style='color:green'>●</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>OQC</td>\n",
+       "        <td style='text-align:left'>Lucy</td>\n",
+       "        <td style='text-align:left'><code>aws_oqc_lucy</code></td>\n",
+       "        <td><span style='color:red'>○</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>QuEra</td>\n",
+       "        <td style='text-align:left'>Aquila</td>\n",
+       "        <td style='text-align:left'><code>aws_quera_aquila</code></td>\n",
+       "        <td><span style='color:green'>●</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>Rigetti</td>\n",
+       "        <td style='text-align:left'>Aspen-M-3</td>\n",
+       "        <td style='text-align:left'><code>aws_rigetti_aspen_m3</code></td>\n",
+       "        <td><span style='color:red'>○</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>qBraid</td>\n",
+       "        <td style='text-align:left'>QIR sparse simulator</td>\n",
+       "        <td style='text-align:left'><code>qbraid_qir_simulator</code></td>\n",
+       "        <td><span style='color:green'>●</span></td></tr>\n",
+       "        <tr><td colspan='4'; style='text-align:right'>Device status updated 20 minutes ago</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "from qbraid import device_wrapper, get_devices\n",
-    "get_devices() "
+    "from qbraid import get_devices\n",
+    "\n",
+    "get_devices()"
    ]
   },
   {
@@ -394,13 +642,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ibm_q_sherbrooke\n"
+     ]
+    }
+   ],
    "source": [
-    "from qbraid.devices.ibm import ibm_least_busy_qpu\n",
+    "from qbraid.providers.ibm import QiskitProvider\n",
     "\n",
-    "ibm_device_id = ibm_least_busy_qpu()\n",
+    "provider = QiskitProvider()\n",
+    "\n",
+    "ibm_device_id = provider.ibm_least_busy_qpu()\n",
     "\n",
     "print(ibm_device_id)"
    ]
@@ -414,11 +672,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
-    "qbraid_ibm_device = device_wrapper(ibm_device_id)"
+    "from qbraid.providers import QbraidProvider\n",
+    "\n",
+    "provider = QbraidProvider()\n",
+    "\n",
+    "qbraid_ibm_device = provider.get_device(ibm_device_id)"
    ]
   },
   {
@@ -432,7 +694,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -448,9 +710,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<JobStatus.QUEUED: 'job is queued'>"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "qbraid_ibm_job.status()"
    ]
@@ -467,24 +740,6 @@
    "metadata": {},
    "source": [
     "If you got the error \"AccountNotFoundError\", when calling the \"run\" method above, you will need to fix this by running the following cells (currently commented out)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#! rm -rf ~/.qiskit"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#! qbraid jobs enable qbraid_sdk"
    ]
   },
   {
@@ -510,20 +765,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
-    "device_2 = device_wrapper('aws_ionq')\n",
+    "device_2 = provider.get_device(\"aws_ionq_harmony\")\n",
     "\n",
-    "quantum_job2 = device_2.run(circ, shots = 250)"
+    "quantum_job2 = device_2.run(circ, shots=250)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<JobStatus.QUEUED: 'job is queued'>"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "quantum_job2.status()"
    ]
@@ -544,18 +810,76 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qbraid import get_jobs, job_wrapper"
+    "from qbraid import get_jobs\n",
+    "from qbraid.providers import QuantumJob"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<h3>Quantum Jobs</h3><table><tr>\n",
+       "    <th style='text-align:left'>qBraid ID</th>\n",
+       "    <th style='text-align:left'>Submitted</th>\n",
+       "    <th style='text-align:left'>Status</th></tr>\n",
+       "    <tr>\n",
+       "        <td style='text-align:left'>aws_ionq_harmony-ryanjh88-qjob-rh38fuh3xqy35ycowkbi</td>\n",
+       "        <td style='text-align:left'>2024-05-09T00:52:12.697Z</td>\n",
+       "        <td style='text-align:left'><span style='color:blue'>QUEUED</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>ibm_q_sherbrooke-ryanjh88-qjob-96uu4giud50rbyhfks0s</td>\n",
+       "        <td style='text-align:left'>2024-05-09T00:51:58.397Z</td>\n",
+       "        <td style='text-align:left'><span style='color:blue'>QUEUED</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>aws_ionq_harmony-ryanjh88-qjob-s1gxyrzi10t3pfvgsfav</td>\n",
+       "        <td style='text-align:left'>2024-05-09T00:38:06.528Z</td>\n",
+       "        <td style='text-align:left'><span style='color:blue'>QUEUED</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>ibm_q_sherbrooke-ryanjh88-qjob-u345imaofh0wrejpg3lq</td>\n",
+       "        <td style='text-align:left'>2024-05-09T00:37:33.259Z</td>\n",
+       "        <td style='text-align:left'><span style='color:blue'>QUEUED</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>ibm_q_sherbrooke-ryanjh88-qjob-zba9va3bbli2w9fdgxlw</td>\n",
+       "        <td style='text-align:left'>2024-05-09T00:30:48.338Z</td>\n",
+       "        <td style='text-align:left'><span style='color:blue'>QUEUED</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>ibm_q_qasm_simulator-ryanjh88-qjob-rc7i4qklfnxduh5u9sg1</td>\n",
+       "        <td style='text-align:left'>2024-04-30T17:37:46.876Z</td>\n",
+       "        <td style='text-align:left'><span style='color:blue'>INITIALIZING</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>ibm_q_qasm_simulator-ryanjh88-qjob-jsnp8jm50t0ahb7hs5sv</td>\n",
+       "        <td style='text-align:left'>2024-04-30T17:37:39.962Z</td>\n",
+       "        <td style='text-align:left'><span style='color:green'>COMPLETED</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>ibm_q_simulator_statevector-ryanjh88-qjob-5sp04guqoaeqefm7np55</td>\n",
+       "        <td style='text-align:left'>2024-04-30T17:37:10.008Z</td>\n",
+       "        <td style='text-align:left'><span style='color:green'>COMPLETED</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>ibm_q_qasm_simulator-ryanjh88-qjob-w899sdob235ritsj11p6</td>\n",
+       "        <td style='text-align:left'>2024-04-30T17:36:55.629Z</td>\n",
+       "        <td style='text-align:left'><span style='color:green'>COMPLETED</span></td></tr>\n",
+       "        <tr>\n",
+       "        <td style='text-align:left'>ibm_q_qasm_simulator-ryanjh88-qjob-9nrs4a1rt1bry9eughzn</td>\n",
+       "        <td style='text-align:left'>2024-04-30T17:36:48.498Z</td>\n",
+       "        <td style='text-align:left'><span style='color:blue'>INITIALIZING</span></td></tr>\n",
+       "        <tr><td colspan='4'; style='text-align:right'>Displaying 10 most recent jobs</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "get_jobs()"
    ]
@@ -569,12 +893,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
-    "saved_job_id = 'ibmq_belem-coladan-qjob-tgc2ltxah608mmap644a' #insert the qBraid ID of one of your submitted jobs from the list above\n",
-    "qjob = job_wrapper(saved_job_id)"
+    "saved_job_id = \"ibm_q_simulator_statevector-ryanjh88-qjob-pusstm180gy7zwx4k7xa\"  # insert the qBraid ID of one of your submitted jobs from the list above\n",
+    "qjob = QuantumJob.retrieve(saved_job_id)"
    ]
   },
   {
@@ -586,21 +910,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'010': 7, '011': 3}, {'010': 6, '011': 4}, {'010': 8, '011': 2}]\n"
+     ]
+    }
+   ],
    "source": [
     "qresult = qjob.result()\n",
-    "qresult.measurement_counts()\n",
-    "qresult.plot_counts()"
+    "\n",
+    "counts = qresult.measurement_counts()\n",
+    "\n",
+    "print(counts)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
+   "execution_count": 20,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAioAAAGxCAYAAABMeZ2uAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAABTB0lEQVR4nO3deXgV9d3//+c52feQlSRkIQtZICQxAUEtLkWRiopabalaLFpbvy61etvq7a+30A1tq7XafrX65abW1qKiqCgtCgqiYrOxJAECWclGwhJOQpaTcM75/ZGbCblBEQRmwNfjunJp3pnlnU+YOa8zM2fG5vF4PIiIiIhYkN3sBkREREQ+i4KKiIiIWJaCioiIiFiWgoqIiIhYloKKiIiIWJaCioiIiFiWgoqIiIhYloKKiIiIWJaCioiIiFiWgoqIiIhYlqlBpbu7m3vvvZfk5GQCAgI477zzKCkpMbMlERERsRBTg8ptt93Ge++9x4svvkhFRQWXXXYZ06dPp6Wlxcy2RERExCJsZj2UsK+vj5CQEN58802uuOIKo15YWMjMmTP55S9/aUZbIiIiYiHeZq344MGDuFwu/P39R9QDAgL46KOPjjqP0+nE6XQa37vdbvbt20dkZCQ2m+2U9isiIiInh8fjobu7m/j4eOz2Y5zc8Zho6tSpngsvvNDT0tLiOXjwoOfFF1/02O12z7hx4446/SOPPOIB9KUvfelLX/rS11nw1dTUdMysYNqpH4Da2lrmzZvHhx9+iJeXF+eccw7jxo2jrKyMrVu3HjH9/z6i4nA4SEpKoqmpidDQ0NPZuoiIiJygrq4uEhMT2b9/P2FhYZ87rWmnfgDS0tJYu3YtPT09dHV1ERcXx7e+9S1SU1OPOr2fnx9+fn5H1ENDQxVUREREzjBf5LINS9xHJSgoiLi4ODo7O1m5ciVXX3212S2JiIiIBZh6RGXlypV4PB4yMzOpqanhgQceICsri+9973tmtiUiIiIWYeoRFYfDwZ133klWVhbf/e53ueCCC1i5ciU+Pj5mtiUiIiIWYerFtF9WV1cXYWFhOBwOXaMiIiInhdvtZmBgwOw2zmg+Pj54eXl95s+P5/Xb1FM/IiIiVjIwMEB9fT1ut9vsVs544eHhjB49+kvf50xBRUREBPB4PLS1teHl5UViYuKxb0QmR+XxeOjt7aWjowOAuLi4L7U8BRURERGG7pje29tLfHw8gYGBZrdzRgsICACgo6ODmJiYzz0NdCyKiyIiIoDL5QLA19fX5E7ODofC3uDg4JdajoKKiIjIYfTsuJPjZI2jgoqIiIhYloKKiIjIV8SaNWuw2Wzs37/f7Fa+MF1MKyIi8jlSHnzntK6v4dErjmv6W265hf379/PGG2+cmoaA/v5+7r//fpYsWYLT6WTGjBn83//7f4mNjT1l6zxER1RERETkc/34xz9m+fLlvPrqq6xdu5bW1lauvfba07JuBRUREZGzhNPp5J577iEmJgZ/f38uuOACSkpKjpju448/ZuLEifj7+zNlyhQqKys/c5kOh4NFixbxxBNPcMkll1BYWMjixYv55JNP+PTTT0/lrwMoqIiIiJw1fvKTn/Daa6/xwgsvUF5eTnp6OjNmzGDfvn0jpnvggQd4/PHHKSkpITo6miuvvPIzP0ZcVlbG4OAg06dPN2pZWVkkJSWxfv36U/r7gIKKiIjIWaGnp4dnnnmG3/72t8ycOZOcnByef/55AgICWLRo0YhpH3nkES699FJyc3N54YUXaG9vZ9myZUdd7q5du/D19SU8PHxEPTY2ll27dp2qX8egoCIiInIWqK2tZXBwkPPPP9+o+fj4MHnyZLZu3Tpi2qlTpxr/HxERQWZm5hHTWIWCioiIiHym0aNHMzAwcMRHmtvb2xk9evQpX7+CioiIyFkgLS0NX19fPv74Y6M2ODhISUkJOTk5I6Y9/CLYzs5Otm/fTnZ29lGXW1hYiI+PD6tXrzZq1dXV7Ny5c8SRmVNF91ERERE5CwQFBXHHHXfwwAMPEBERQVJSEr/5zW/o7e3l1ltvHTHtz3/+cyIjI4mNjeXhhx8mKiqK2bNnH3W5YWFh3Hrrrdx3331EREQQGhrK3XffzdSpU5kyZcop/70UVERERM5gbrcbb++hl/NHH30Ut9vNzTffTHd3N0VFRaxcuZJRo0aNmOfRRx/lRz/6ETt27CA/P5/ly5d/7sMYf//732O327nuuutG3PDtdLB5PB7PaVnTKdDV1UVYWBgOh4PQ0FCz2xERkTNYf38/9fX1jB07Fn9/f7Pb+cIuv/xy0tPT+eMf/2h2KyN83ngez+u3rlEROYOsWLGCc845h/z8fCZMmMALL7xgdksiYpLOzk7efvtt1qxZM+IeJ2cbnfoROUN4PB5uuukm1qxZw8SJE2loaCArK4trr72WkJAQs9sTkdNs3rx5lJSUcP/993P11Veb3c4po6AicgY5/KmnXV1dREZG4ufnZ25TImKKz7pB29lGQUXkDGGz2Xj55Ze59tprCQoKorOzk9dff/1zL4ATETnT6RoVkTPEwYMH+eUvf8nrr79OY2Mjq1ev5uabb2bPnj1mtyYicsooqIicITZu3EhrayvTpk0DYNKkSYwZM4YNGzaY3JmIyKmjoCJyhkhMTKStrc14HkdNTQ21tbVkZmaa3JmIyKmja1REzhCxsbE899xz3HDDDdjtdtxuN3/84x9JSkoyuzURkVNGQUXkDDJnzhzmzJljdhsiIqeNTv2IiIh8RaxZs2bEbQ7OBDqiIiIi8nnmh53m9TmOa/JbbrmF/fv388Ybb5yafoDnnnuOl156ifLycrq7u+ns7CQ8PPyUre9wOqIiIiIin6u3t5fLL7+c//zP/zzt6zY1qLhcLn72s58xduxYAgICSEtL4xe/+AVn8HMSRURETON0OrnnnnuIiYnB39+fCy64gJKSkiOm+/jjj5k4cSL+/v5MmTKFysrKz13uvffey4MPPsiUKVNOVeufydSg8thjj/HMM8/wxz/+ka1bt/LYY4/xm9/8hqefftrMtkRERM5IP/nJT3jttdd44YUXKC8vJz09nRkzZrBv374R0z3wwAM8/vjjlJSUEB0dzZVXXsng4KBJXX8+U4PKJ598wtVXX80VV1xBSkoK3/zmN7nssssoLi42sy0REZEzTk9PD8888wy//e1vmTlzJjk5OTz//PMEBASwaNGiEdM+8sgjXHrppeTm5vLCCy/Q3t5u2WcHmRpUzjvvPFavXs327dsB2LRpEx999BEzZ8486vROp5Ourq4RXyIiIgK1tbUMDg5y/vnnGzUfHx8mT55s3CjykKlTpxr/HxERQWZm5hHTWIWpn/p58MEH6erqIisrCy8vL1wuF7/61a+48cYbjzr9woULWbBgwRH10tJSgoODAcjPz6e7u5va2lrj54eWX1VVZdRSUlKIjIykrKzMqMXGxpKcnMzGjRsZGBgAICwsjMzMTLZt22YEIz8/P/Ly8mhoaKCjo8OYf9KkSbS3t7Nz506jlpuby8DAANXV1UYtPT2doKAgNm3aZNTGjBlDfHw8JSUlxjU6UVFRpKamUlFRQV9fHwDBwcHk5OSwY8cOOjs7AfDy8qKwsJDm5mZaW1uNZRYUFOBwOKirqzNq2dnZ2Gw2tmzZMmIsIiIiKC8vN2qjR48mKSmJDRs2GIcDw8PDGTduHFu3bqW7uxsAf39/Jk6cSH19Pbt37zbmnzx5Mm1tbTQ1NY0YC6fTaQRTgIyMDAICAti8ebNRS0xMJC4ubsSRtS86Ft7e3pxzzjk0NTXR1tY2Yiz2799PfX39iLEARmycY8eOJTw8fMRt6ePi4khMTKS8vJx/1f4LgGZXM+uc65juP51oezQADo+DFX0rONf3XFK9UwHw4GFJ7xKyfbLJ98k3lrm8bzlh9jCm+U0zamuda+l2dzMrYJZR2zCwgW0HtzEncPjeKbUHaykeKGZWwCxCbCEAdLg7WN2/mml+00jwSgCg39PPsr5lFPgUkOWTZcy/tHcpSd5JTPadbNTe7X8XO3am+083auud62lztXFt4LVGrWqwis2Dm7ku8Dq+kfwNAEaNGkVGRgZbtmzhwIEDAAQEBJCbm0tdXZ3xLCKbzcakSZNobW2lubnZWGZeXh49PT3U1NQYtczMTHx9famoqDBqSUlJxMbGjjjfHhMTQ0pKCps2bcLpdAIQGhpKVlYW1dXVOBxDn57w9fUlPz+fxsZG2tvbjfkLCwvZu3cvDQ0NRm38+PG4XC62bdtm1NLS0ggJCWHjxo1GLSEhgYSEBMrKynC5XMDQDj89PZ2qqip6enoACAwMZMKECdTW1rJ3714A7HY7RUVFtLS00NLScsyx8PHxGXENQXJyMtHR0ZSWlhq1Q/uvw8fi0P7r8LE4tP/632NRVFTE7t27aWxsNGoTJkxgcHDwmPuvQ2NRWlqK2+0GIDIykrS0NCorK+nt7QUgKCiI8ePHU1NTY5yKOLT/+t9jYda+3NfXF4/Hw+DgoDFvEKfXwMDAiNMwAQEBuFwuox8Y2vcC9Pf3c/DgQVwulzFPb2+v8e/P23voZf7gwYP09PQY+0+Avr4+4+916L9Op5ODBw8a0wQFBY3o59D8h5Z3iJ+fH3a7fcTyD20Xh+/fD+3LD/8bHovNY+KVq0uWLOGBBx7gt7/9LePHj2fjxo3ce++9PPHEE8ydO/eI6Z1Op7EBwtBj7hMTE3E4HISGhp7O1uUrKveFXLNbsIyKuRXHnkjkDNLf3099fT1jx441ggBwxnw8+e9//zsREREsXryY73znOwAMDg4yduxY7r33Xv7jP/6DNWvWcPHFF/Pyyy9zww03ANDZ2cmYMWNYvHixUfssh+b/Ih9P/szxZOj1Oyws7Au9fpt6ROWBBx7gwQcf5Nvf/jYw9I67sbGRhQsXHjWo+Pn54efnd7rbFBERsbygoCDuuOMOHnjgASIiIkhKSuI3v/kNvb293HrrrSOm/fnPf05kZCSxsbE8/PDDREVFMXv27M9c9q5du9i1a5dxtK+iooKQkBCSkpKIiIg4lb+WuUGlt7cXu33kZTJeXl7GISgRERHTHecRjtPN7XYbp3geffRR3G43N998M93d3RQVFbFy5UpGjRo1Yp5HH32UH/3oR+zYsYP8/HyWL1+Or6/vZ67j2WefHXHpxaGnuC9evJhbbrnl5P9ShzE1qFx55ZX86le/IikpifHjx7NhwwaeeOIJ5s2bZ2ZbIiIiZ4yOjg7S09OBoWtXnnrqKZ566qmjTnvRRRcZ10HOmjXrqNMczfz585k/f/6X7vVEmBpUnn76aX72s5/xf/7P/6Gjo4P4+Hh+8IMf8F//9V9mtiUiImJ5nZ2dfPzxx6xZs4Yf/vCHZrdzypgaVEJCQnjyySd58sknzWxDRETkjDNv3jxKSkq4//77ufrqq81u55TRQwlFRETOQFa9QdvJpocSioiIiGUpqIiIiIhlKaiIiIiIZSmoiIiIiGUpqIiIiIhlKaiIiIiIZSmoiIiIfEWsWbMGm83G/v37zW7lC9N9VERERD7H6X5q+vE+mfzQ05PfeOONU9LPvn37eOSRR3j33XfZuXMn0dHRzJ49m1/84heEhZ36J0srqIiIiMhnam1tpbW1ld/97nfk5OTQ2NjID3/4Q1pbW1m6dOkpX79O/YiIiJwlnE4n99xzDzExMfj7+3PBBRdQUlJyxHQff/wxEydOxN/fnylTplBZWfmZy5wwYQKvvfYaV155JWlpaVxyySX86le/Yvny5Rw8ePBU/jqAgoqIiMhZ4yc/+QmvvfYaL7zwAuXl5aSnpzNjxgz27ds3YroHHniAxx9/nJKSEqKjo7nyyisZHBz8wutxOByEhobi7X3qT8woqIiIiJwFenp6eOaZZ/jtb3/LzJkzycnJ4fnnnycgIIBFixaNmPaRRx7h0ksvJTc3lxdeeIH29vYv/OygPXv28Itf/ILbb7/9VPwaR1BQEREROQvU1tYyODjI+eefb9R8fHyYPHkyW7duHTHt1KlTjf+PiIggMzPziGmOpquriyuuuIKcnBzmz59/0nr/PAoqIiIickzd3d1cfvnlhISEsGzZMnx8fE7LehVUREREzgJpaWn4+vry8ccfG7XBwUFKSkrIyckZMe2nn35q/H9nZyfbt28nOzv7M5fd1dXFZZddhq+vL2+99Rb+/v4n/xf4DPp4soiIyFkgKCiIO+64gwceeICIiAiSkpL4zW9+Q29vL7feeuuIaX/+858TGRlJbGwsDz/8MFFRUcyePfuoyz0UUnp7e/nb3/5GV1cXXV1dAERHR+Pl5XVKfy8FFRERkc9xvDdgO93cbrfx6ZtHH30Ut9vNzTffTHd3N0VFRaxcuZJRo0aNmOfRRx/lRz/6ETt27CA/P5/ly5fj6+t71OWXl5fz73//G4D09PQRP6uvryclJeXk/1KHUVARERE5g3V0dBgBwt/fn6eeeoqnnnrqqNNedNFFeDweAGbNmvWFln/4PGZQULGgvXv38vWvf934vre3l7q6Ojo6OoiIiDCxMxERsYrOzk4+/vhj1qxZww9/+EOz2zllFFQsKDIyko0bNxrf/+53v2Pt2rUKKSIiYpg3bx4lJSXcf//9XH311Wa3c8ooqJwBFi1axMKFC81uQ0RELOSL3qDtTKePJ1vcJ598Qmdn5xc+lygiInI2UVCxuEWLFvHd7373tDxPQUREMPXC0bPJyRpHvfpZ2IEDB3jllVeO+uRLERE5uQ7dD2RgYICAgACTuznz9fb2AnzpO9gqqFjYyy+/TF5eHllZWWa3IiJy1vP29iYwMJDdu3fj4+OD3a6TDifC4/HQ29tLR0cH4eHhX/qGcAoqFrZo0SK+//3vm92GiMhXgs1mIy4ujvr6ehobG81u54wXHh7O6NGjv/RyFFQs7JNPPjG7BRGRrxRfX18yMjIYGBgwu5Uzmo+Pz0m7tb6CioiIyGHsdvtpfeiefD6dgBMRERHLMjWopKSkYLPZjvi68847zWxLRERELMLUUz8lJSW4XC7j+8rKSi699FKuv/56E7sSERERqzA1qERHR4/4/tFHHyUtLY0LL7zQpI5ERETESixzMe3AwAB/+9vfuO+++7DZbEedxul04nQ6je+7urpOV3siIiJiAssElTfeeIP9+/dzyy23fOY0CxcuZMGCBUfUS0tLCQ4OBiA/P5/u7m5qa2uNn2dlZeHl5UVVVZVRS0lJITIykrKyMqMWGxtLcnIyGzduZGBggH9V7qK5x8a7LXYuH+MiPnBouu5BeLXei6kxbrLDh28RvHi7nexwD1NihmuvN9gJ8oYZY9xGbXWrnb39cEPqcK1sj41N++zckuHC/j85bUeXjXW77FyT7GKU31Ctox/e3unFJfFuUoKH1uN0w99rvCiMcpMXMbzul2rtJATBhaOH1/NOkx23B65MGq591G6jvtvGzenDtYpOGyW77cxJc3FN3tDn4MPDwxk3bhxbt26lu7sbAH9/fyZOnEh9fT27d+825p88eTJtbW00NTUZtdzcXJxOJ9u3bzdqGRkZBAQEsHnzZqOWmJhIXFwcxcXFRi0qKorU1FQqKiro6+sDIDg4mJycHHbs2EFnZycwdMOmc845h6amJtra2oz5CwoK2L9/P/X19UYtOzsbgK1btxq1sWPHEh4ezoYNG4xaXFwciYmJlJeXMydwDgDNrmbWOdcx3X860fahI4MOj4MVfSs41/dcUr1TAfDgYUnvErJ9ssn3yTeWubxvOWH2MKb5TTNqa51r6XZ3Mytg+LlOGwY2sO3gNmO9ALUHaykeKGZWwCxCbCEAdLg7WN2/mml+00jwSgCg39PPsr5lFPgUkOUzfNPApb1LSfJOYrLvZKP2bv+72LEz3X+6UVvvXE+bq41rA681alWDVWwe3Mx1gdcZf59Ro0aRkZHBli1bOHDgAAABAQHk5uZSV1fHnj17gKF7VEyaNInW1laam5uNZebl5dHT00NNTY1Ry8zMxNfXl4qKCqOWlJREbGzsiDs1x8TEkJKSwqZNm4w3MaGhoWRlZVFdXY3D4QCGPnKan59PY2Mj7e3txvyFhYXs3buXhoYGozZ+/HhcLhfbtm0zamlpaYSEhIx4qnlCQgIJCQmUlZUZp7AjIiJIT0+nqqqKnp4eAAIDA5kwYQK1tbXs3bsXGPpUSVFRES0tLbS0tBxzLHx8fKisrDRqycnJREdHU1paatQO7b8OH4uwsDAyMzNHjIWfnx95eXlHjEVRURG7d+8ecf+QCRMmMDg4SHV1tVFLT08nKCiITZs2HTEWpaWluN1D+5HIyEjS0tKorKw07lAaFBTE+PHjqampYd++fcDQ3WALCwuPGIuTuS8/fCy2bdtmvMk9NBYNDQ10dHQY80+aNIn29nZ27txp1HJzcxkYGDjmWIwZM4b4+HhKSkqMW8h/0f3XobFobm6mtbXVWGZBQQEOh4O6ujqjlp2djc1mY8uWLSPGIiIigvLycqM2evRokpKS2LBhA4ODg4A19uWH/w2PxeaxyEMNZsyYga+vL8uXL//MaY52RCUxMRGHw0FoaOhJ7ynlwXdO+jLPRA2PXmF2C5aR+0Ku2S1YRsXcimNPJCJyFF1dXYSFhX2h129LHFFpbGxk1apVvP766587nZ+fH35+fqepKxERETGbJe6jsnjxYmJiYrjiCr1zFxERkWGmBxW3283ixYuZO3cu3t6WOMAjIiIiFmF6UFm1ahU7d+5k3rx5ZrciIiIiFmP6IYzLLrsMi1zPKyIiIhZj+hEVERERkc+ioCIiIiKWpaAiIiIilqWgIiIiIpaloCIiIiKWpaAiIiIilqWgIiIiIpaloCIiIiKWpaAiIiIilqWgIiIiIpaloCIiIiKWpaAiIiIilqWgIiIiIpaloCIiIiKWpaAiIiIilqWgIiIiIpaloCIiIiKWpaAiIiIilqWgIiIiIpaloCKW53Q6ueuuu8jIyCA3N5ebbrrJ7JZEROQ08Ta7AZFjefDBB7HZbGzfvh2bzcauXbvMbklERE4TBRWxtJ6eHhYtWkRzczM2mw2A0aNHm9yViIicLjr1I5ZWW1tLREQEv/71rykqKuJrX/saq1evNrstERE5TRRUxNIOHjxIY2MjOTk5lJaW8tRTT/Gtb32L9vZ2s1sTEZHTQEFFLC0pKQm73c6NN94IQEFBAWPHjqWiosLkzkRE5HRQUBFLi4qK4utf/zorV64EoL6+nvr6erKzs03uTERETgddTCuW9+yzz3Lrrbfy05/+FLvdzp///GcSEhLMbktERE4DBRWxvNTUVD744AOz2xARERPo1I+IiIhYloKKiIiIWJbpQaWlpYWbbrqJyMhIAgICyM3NpbS01Oy2RERExAJMvUals7OT888/n4svvph//vOfREdHs2PHDkaNGmVmWyIiImIRpgaVxx57jMTERBYvXmzUxo4da2JHIiIiYiWmnvp56623KCoq4vrrrycmJoaCggKef/75z5ze6XTS1dU14ktERETOXjaPx+Mxa+X+/v4A3HfffVx//fWUlJTwox/9iGeffZa5c+ceMf38+fNZsGDBEfXVq1cTHBwMQH5+Pt3d3dTW1ho/z8rKwsvLi6qqKqOWkpJCZGQkZWVlRi02Npbk5GQ2btzIwMAA/6rcRXOPjXdb7Fw+xkV84NB03YPwar0XU2PcZIcPD9/i7Xaywz1MiRmuvd5gJ8gbZoxxD/fbamdvP9yQOlwr22Nj0z47t2S4sA89e48dXTbW7bJzTbKLUX5DtY5+eHunF5fEu0kJHlqP0w1/r/GiMMpNXsTwul+qtZMQBBeOHl7PO0123B64Mmm49lG7jfpuGzenD9cqOm2U7LYzJ83FNb4lAIT31jGu/W22xl1Ht//QfUz8BzuZ2Pwi9VGXsDtkgjH/5PqnaAstoCnya0Ytt/lFnN5hbB99lVHLaF9OwMA+NicO/70T931EnKOc4pS7wDaUpaO6q0jds5qKhBvp840EILi/lZy2peyIuYLOoDQAvF19nLPzeZpGnUdbeJGxzILG59gfOJb66EuNWnbrKwBsjb/BqI3d/R7hvfVsSL7dqMXtLyWx8xPKk77Pv0IiAGh2NbPOuY7p/tOJtkcD4PA4WNG3gnN9zyXVOxUADx6W9C4h2yebfJ98Y5nL+5YTZg9jmt80o7bWuZZudzezAmYZtQ0DG9h2cBtzAucYtdqDtRQPFDMrYBYhthAAOtwdrO5fzTS/aSR4Df1t+j39LOtbRoFPAVk+Wcb8S3uXkuSdxGTfyUbt3f53sWNnuv90o7beuZ42VxvXBl5r1KoGq9g8uJnrAq/jG8nfAGDUqFFkZGSwZcsWDhw4AGBcb1ZXV8eePXsAsNlsTJo0idbWVpqbm41l5uXl0dPTQ01NjVHLzMzE19d3xB2Ik5KSiI2NpaSkxKjFxMSQkpLCpk2bcDqdAISGhpKVlUV1dTUOhwMAX19f8vPzaWxsHPH4hcLCQvbu3UtDQ4NRGz9+PC6Xi23bthm1tLQ0QkJC2Lhxo1FLSEggISGBsrIyXC4XABEREaSnp1NVVUVPTw8AgYGBTJgwgdraWvbu3QuA3W6nqKiIlpYWWlpajjkWPj4+VFZWGrXk5GSio6NHXM93aP91+FiEhYWRmZk5Yiz8/PzIy8s7YiyKiorYvXs3jY2NRm3ChAkMDg5SXV1t1NLT0wkKCmLTpk1HjEVpaSlu99B+JDIykrS0NCorK+nt7QUgKCiI8ePHU1NTw759+wDw8vKisLDwiLE4mfvyw8di27ZtxpvcQ2PR0NBAR0eHMf+kSZNob29n586dRi03N5eBgYFjjsWYMWOIj4+npKSEQy+vUVFRpKamUlFRQV9fHwDBwcHk5OSwY8cOOjs7R4xFc3Mzra2txjILCgpwOBzU1dUZtezsbGw2G1u2bBkxFhEREZSXlxu10aNHk5SUxIYNGxgcHAQgPDyccePGsXXrVrq7u4Gh1+OJEydSX1/P7t27jfknT55MW1sbTU1NI8bC6XSyfft2o5aRkUFAQACbN282aomJicTFxVFcXGzUDo3F+vXrOe+883A4HISGhvJ5TA0qvr6+FBUV8cknnxi1e+65h5KSEtavX3/E9E6n09gAAbq6ukhMTPxCv+iJSHnwnZO+zDNRg/93zG7BMnLHJpndgmVUzNVjDETkxHR1dREWFvaFXr9NPfUTFxdHTk7OiFp2dvaIFHs4Pz8/QkNDR3yJiIjI2cvUoHL++eePOIwGsH37dpKTk03qSERERKzE1KDy4x//mE8//ZRf//rX1NTU8NJLL/Hcc89x5513mtmWiIiIWISpQWXSpEksW7aMf/zjH0yYMIFf/OIXPPnkk9x4441mtiUiIiIWYfpDCWfNmsWsWbOOPaGIiIh85Zh+C30RERGRz6KgIiIiIpaloCIiIiKWpaAiIiIilqWgIiIiIpaloCIiIiKWpaAiIiIilqWgIiIiIpaloCIiIiKWpaAiIiIilqWgIiIiIpaloCIiIiKWpaAiIiIilqWgIiIiIpaloCIiIiKWpaAiIiIilqWgIiIiIpaloCIiIiKWpaAiIiIilqWgIiIiIpaloCIiIiKWpaAiIiIilqWgIiIiIpaloCIiIiKWpaAiIiIilqWgIiIiIpaloCIiIiKWpaAiIiIilqWgIiIiIpaloCIiIiKWZWpQmT9/PjabbcRXVlaWmS2JiIiIhXib3cD48eNZtWqV8b23t+ktiYiIiEWYngq8vb0ZPXq02W2IiIiIBZ3QqZ/y8nIqKiqM7998801mz57Nf/7nfzIwMHBcy9qxYwfx8fGkpqZy4403snPnzs+c1ul00tXVNeJLREREzl42j8fjOd6ZJk2axIMPPsh1111HXV0d48eP55prrqGkpIQrrriCJ5988gst55///CcHDhwgMzOTtrY2FixYQEtLC5WVlYSEhBwx/fz581mwYMER9dWrVxMcHAxAfn4+3d3d1NbWGj/PysrCy8uLqqoqo5aSkkJkZCRlZWVGLTY2luTkZDZu3MjAwAD/qtxFc4+Nd1vsXD7GRXzg0HTdg/BqvRdTY9xkhw8P3+LtdrLDPUyJGa693mAnyBtmjHEP99tqZ28/3JA6XCvbY2PTPju3ZLiw24ZqO7psrNtl55pkF6P8hmod/fD2Ti8uiXeTEjy0Hqcb/l7jRWGUm7yI4XW/VGsnIQguHD28nnea7Lg9cGXScO2jdhv13TZuTh+uVXTaKNltZ06ai2t8SwAI761jXPvbbI27jm7/BAD8BzuZ2Pwi9VGXsDtkgjH/5PqnaAstoCnya0Ytt/lFnN5hbB99lVHLaF9OwMA+NifONWqJ+z4izlFOccpdYBvK0lHdVaTuWU1Fwo30+UYCENzfSk7bUnbEXEFnUBoA3q4+ztn5PE2jzqMtvMhYZkHjc+wPHEt99KVGLbv1FQC2xt9g1Mbufo/w3no2JN9u1OL2l5LY+QnlSd/nXyERADS7mlnnXMd0/+lE26MBcHgcrOhbwbm+55LqnQqABw9LepeQ7ZNNvk++sczlfcsJs4cxzW+aUVvrXEu3u5tZAbOM2oaBDWw7uI05gXOMWu3BWooHipkVMIsQ29B20uHuYHX/aqb5TSPBa+hv0+/pZ1nfMgp8CsjyGb72a2nvUpK8k5jsO9movdv/LnbsTPefbtTWO9fT5mrj2sBrjVrVYBWbBzdzXeB1fCP5GwCMGjWKjIwMtmzZwoEDBwAICAggNzeXuro69uzZA4DNZmPSpEm0trbS3NxsLDMvL4+enh5qamqMWmZmJr6+viPeECUlJREbG0tJSYlRi4mJISUlhU2bNuF0OgEIDQ0lKyuL6upqHA4HAL6+vuTn59PY2Eh7e7sxf2FhIXv37qWhocGojR8/HpfLxbZt24xaWloaISEhbNy40aglJCSQkJBAWVkZLpcLgIiICNLT06mqqqKnpweAwMBAJkyYQG1tLXv37gXAbrdTVFRES0sLLS0txxwLHx8fKisrjVpycjLR0dGUlpYatUP7r8PHIiwsjMzMzBFj4efnR15e3hFjUVRUxO7du2lsbDRqEyZMYHBwkOrqaqOWnp5OUFAQmzZtOmIsSktLcbuH9iORkZGkpaVRWVlJb28vAEFBQYwfP56amhr27dsHgJeXF4WFhUeMxcnclx8+Ftu2bTPe5B4ai4aGBjo6Ooz5J02aRHt7+4g3zrm5uQwMDBxzLMaMGUN8fDwlJSUcenmNiooiNTWViooK+vr6AAgODiYnJ4cdO3bQ2dk5Yiyam5tpbW01lllQUIDD4aCurs6oZWdnY7PZ2LJly4ixiIiIoLy83KiNHj2apKQkNmzYwODgIADh4eGMGzeOrVu30t3dDYC/vz8TJ06kvr6e3bt3G/NPnjyZtrY2mpqaRoyF0+lk+/btRi0jI4OAgAA2b95s1BITE4mLi6O4uNioHRqL9evXc9555+FwOAgNDeXznFBQCQsLo7y8nLS0NB577DHef/99Vq5cyccff8y3v/3tEb/Q8di/fz/Jyck88cQT3HrrrUf83Ol0GhsgQFdXF4mJiV/oFz0RKQ++c9KXeSZq8P+O2S1YRu7YJLNbsIyKuRXHnkhE5Ci6uroICwv7Qq/fJ3SNisfjMVLzqlWrmDVr6B1gYmKi8e7pRBxKeYe/mzicn58ffn5+J7x8ERERObOc0DUqRUVF/PKXv+TFF19k7dq1XHHFFQDU19cTGxt7ws0cOHCA2tpa4uLiTngZIiIicvY4oaDy+9//nvLycu666y4efvhh0tPTAVi6dCnnnXfeF17Of/zHf7B27VoaGhr45JNPuOaaa/Dy8mLOnDnHnllERETOeid06icvL2/ERW6H/Pa3vz2u+6A0NzczZ84c9u7dS3R0NBdccAGffvop0dHRJ9KWiIiInGVOKKikpqZSUlJCZGTkiHp/fz/nnHPOiCuTP8+SJUtOZPUiIiLyFXFCp34aGhqMj+Mdzul0jvjYoYiIiMiXcVxHVN566y3j/1euXElYWJjxvcvlYvXq1YwdO/bkdSciIiJfaccVVGbPng0M3bhp7ty5I37m4+NDSkoKjz/++ElrTkRERL7ajiuoHLp3ytixYykpKSEqKuqUNCUiIiICJ3gxbX19/cnuQ0REROQIJ/z05NWrV7N69Wo6OjqMIy2H/Pd///eXbkxERETkhILKggUL+PnPf05RURFxcXHYbLaT3ZeIiIjIiQWVZ599lr/85S/cfPPNJ7sfEREREcMJ3UdlYGDguG6VLyIiInIiTiio3Hbbbbz00ksnuxcRERGREU7o1E9/fz/PPfccq1atYuLEifj4+Iz4+RNPPHFSmhMREZGvthMKKps3byY/Px+AysrKET/ThbUiIiJyspxQUPnggw9Odh8iIiIiRziha1RERERETocTOqJy8cUXf+4pnvfff/+EGxIRERE55ISCyqHrUw4ZHBxk48aNVFZWHvGwQhEREZETdUJB5fe///1R6/Pnz+fAgQNfqiERERGRQ07qNSo33XSTnvMjIiIiJ81JDSrr16/H39//ZC5SREREvsJO6NTPtddeO+J7j8dDW1sbpaWl/OxnPzspjYmIyFfP4sWLmTdvHsuWLWP27NlmtyMWcEJBJSwsbMT3drudzMxMfv7zn3PZZZedlMZEROSrpaGhgeeff54pU6aY3YpYyAkFlcWLF5/sPkRE5CvM7XZz22238fTTT3P//feb3Y5YyAkFlUPKysrYunUrAOPHj6egoOCkNCUiIl8tTzzxBOeffz6FhYVmtyIWc0JBpaOjg29/+9usWbOG8PBwAPbv38/FF1/MkiVLiI6OPpk9iojIWayyspLXXnuNDz/80OxWxIJO6FM/d999N93d3VRVVbFv3z727dtHZWUlXV1d3HPPPSe7RxEROYutW7eOhoYGMjIySElJ4dNPP+X222/nmWeeMbs1sQCbx+PxHO9MYWFhrFq1ikmTJo2oFxcXc9lll7F///6T1d/n6urqIiwsDIfDQWho6ElffsqD75z0ZZ6JGvy/Y3YLlpE7NsnsFiyjYm6F2S3IWeqiiy7i3nvv1ad+zmLH8/p9QkdU3G43Pj4+R9R9fHxwu90nskgRERGRI5xQULnkkkv40Y9+RGtrq1FraWnhxz/+MV//+tdPWnMiIvLVs2bNGh1NEcMJBZU//vGPdHV1kZKSQlpaGmlpaYwdO5auri6efvrpk92jiIiIfEWd0Kd+EhMTKS8vZ9WqVWzbtg2A7Oxspk+fflKbExERka+24zqi8v7775OTk0NXVxc2m41LL72Uu+++m7vvvptJkyYxfvx41q1bd0KNPProo9hsNu69994Tml9ERETOPscVVJ588km+//3vH/UK3bCwMH7wgx/wxBNPHHcTJSUl/PnPf2bixInHPa+IiIicvY4rqGzatInLL7/8M39+2WWXUVZWdlwNHDhwgBtvvJHnn3+eUaNGHde8IiIicnY7rqDS3t5+1I8lH+Lt7c3u3buPq4E777yTK6644gtd3+J0Ounq6hrxJSIiImev47qYNiEhgcrKStLT04/6882bNxMXF/eFl7dkyRLKy8spKSn5QtMvXLiQBQsWHFEvLS0lODgYgPz8fLq7u6mtrTV+npWVhZeXF1VVVUYtJSWFyMjIEUeAYmNjSU5OZuPGjQwMDDBvnIvmHhvvtti5fIyL+MCh6boH4dV6L6bGuMkOH75f3uLtdrLDPUyJGa693mAnyBtmjBm+v8zqVjt7++GG1OFa2R4bm/bZuSXDhd02VNvRZWPdLjvXJLsY5TdU6+iHt3d6cUm8m5TgofU43fD3Gi8Ko9zkRQyv+6VaOwlBcOHo4fW802TH7YErk4ZrH7XbqO+2cXP6cK2i00bJbjtz0lwU+w7dbTi8t45x7W+zNe46uv0TAPAf7GRi84vUR13C7pAJxvyT65+iLbSApsivGbXc5hdxeoexffRVRi2jfTkBA/vYnDjXqCXu+4g4RznFKXeBbShLR3VXkbpnNRUJN9LnGwlAcH8rOW1L2RFzBZ1BaQB4u/o4Z+fzNI06j7bwImOZBY3PsT9wLPXRlxq17NZXANgaf4NRG7v7PcJ769mQfLtRi9tfSmLnJ5QnfZ85gREANLuaWedcx3T/6UTbhx4Z4fA4WNG3gnN9zyXVOxUADx6W9C4h2yebfJ98Y5nL+5YTZg9jmt80o7bWuZZudzezAmYZtQ0DG9h2cBtzAucYtdqDtRQPFDMrYBYhthAAOtwdrO5fzTS/aSR4Df1t+j39LOtbRoFPAVk+Wcb8S3uXkuSdxGTfyUbt3f53sWNnuv/wG4b1zvW0udq4NvBao1Y1WMXmwc1cF3gdxcXFAIwaNYqMjAy2bNnCgQMHAAgICCA3N5e6ujr27NkDgM1mY9KkSbS2ttLc3GwsMy8vj56eHmpqaoxaZmYmvr6+VFQM31QuKSmJ2NjYEfuLmJgYUlJS2LRpE06nE4DQ0FCysrKorq7G4XAA4OvrS35+Po2NjbS3txvzFxYWsnfvXhoaGoza+PHjcblcxgcFANLS0ggJCWHjxo1GLSEhgYSEBMrKynC5XABERESQnp5OVVUVPT09AAQGBjJhwgRqa2vZu3cvMPTE+aKiIlpaWmhpaTnmWPj4+FBZWWnUkpOTiY6OprS01Kgd2n8dPhZhYWFkZmaOGAs/Pz/y8vKOGIuioiJ2P3khjZEXGbUJLS8xaA+gOu4ao5besYKg/l1sSpo3PBad60nYX0Jpyh24bUNvZiMPVJO2eyWV8d+m1y8GgCBnO+NbX6Ym+nL2BY8DwMs9QGHjs7SEn0vLqHONZebvXES3fwK1McNH8bPaXsPLPUBVwvD2kLLnfSIPVFOWcsfwWDg2kLxvHRsT5zHgPfTaENbbQGb7W2wbfQ1dAYlDYzHoIK/5BRoiL6IjdPjSg0n1T9P+w23s3LnTqOXm5jIwMEB1dfXwWKSnExQUxKZNm4zamDFjiI+Pp6SkhEP3U42KiiI1NZWKigr6+voACA4OJicnhx07dtDZ2Tk0Fl5eFBYW0tzcPOL2HwUFBTgcDurq6oxadnY2NpuNLVu2DI9FSgoRERGUl5cbtdGjR5OUlMSGDRsYHBwEIDw8nHHjxrF161a6u7sB8Pf3Z+LEidTX14844DB58mTa2tpoamoaMRZOp5Pt27cbtYyMDAICAti8ebNRS0xMJC4uzthXHD4Wh78eH8tx3Zn27rvvZs2aNZSUlODv7z/iZ319fUyePJmLL76Yp5566pjLampqoqioiPfee8+4NuWiiy4iPz+fJ5988qjzOJ1OYwOEoTvbJSYm6s60p5juTDtMd6YdpjvTnoXmh5ndgXXMd5jdwVnteO5Me1xHVP6//+//4/XXX2fcuHHcddddZGZmArBt2zb+9Kc/4XK5ePjhh7/QssrKyujo6OCcc84xai6Xiw8//JA//vGPOJ1OvLy8Rszj5+eHn5/f8bQsIiIiZ7DjCiqxsbF88skn3HHHHTz00EPGYS2bzcaMGTP405/+RGxs7Bda1te//vURh3UBvve975GVlcVPf/rTI0KKiIiIfPUc9w3fkpOTWbFiBZ2dndTU1ODxeMjIyDjuT+yEhIQwYcKEEbWgoCAiIyOPqIuIiMhX0wndmRaGLqD7309PFhERETmZTjionApr1qwxuwURERGxkBN6KKGIiIjI6aCgIiIiIpaloCIiIiKWpaAiIiIilqWgIiIiIpaloCIiIiKWpaAiIiIilqWgIiIiIpaloCIiIiKWpaAiIiIilqWgIiIiIpaloCIiIiKWpaAiIiIilqWgIiIiIpaloCIiIiKWpaAiIiIilqWgIiIiIpaloCIiIiKWpaAiIiIiluVtdgMiIl9ll112Gbt27cJutxMSEsJTTz1FQUGB2W2JWIaCioiIiV555RXCw8MBWLZsGbfccgubNm0ytykRC9GpHxEREx0KKQAOhwObzWZeMyIWpCMqIiIm++53v8sHH3wAwIoVK0zuRsRadERFRMRkf/3rX2lqauKXv/wlP/3pT81uR8RSFFRERCxi7ty5fPDBB+zdu9fsVkQsQ0FFRMQk+/fvp7W11fj+jTfeIDIykoiICBO7ErEWXaMiImISh8PB9ddfT19fH3a7nejoaN5++21dUCtyGAUVERGTJCcnU1xcbHYbIpamUz8iIiJiWQoqIiIiYlmmBpVnnnmGiRMnEhoaSmhoKFOnTuWf//ynmS2JiIiIhZgaVMaMGcOjjz5KWVkZpaWlXHLJJVx99dVUVVWZ2ZaIiIhYhKkX01555ZUjvv/Vr37FM888w6effsr48eNN6kpERESswjKf+nG5XLz66qv09PQwderUo07jdDpxOp3G911dXaerPRERETGB6UGloqKCqVOn0t/fT3BwMMuWLSMnJ+eo0y5cuJAFCxYcUS8tLSU4OBiA/Px8uru7qa2tNX6elZWFl5fXiFNKKSkpREZGUlZWZtRiY2NJTk5m48aNDAwMMG+ci+YeG++22Ll8jIv4wKHpugfh1Xovpsa4yQ73GPMv3m4nO9zDlJjh2usNdoK8YcYYt1Fb3Wpnbz/ckDpcK9tjY9M+O7dkuLD/zy0UdnTZWLfLzjXJLkb5DdU6+uHtnV5cEu8mJXhoPU43/L3Gi8IoN3kRw+t+qdZOQhBcOHp4Pe802XF74Mqk4dpH7Tbqu23cnD5cq+i0UbLbzpw0F8W+9wAQ3lvHuPa32Rp3Hd3+CQD4D3YysflF6qMuYXfIBGP+yfVP0RZaQFPk14xabvOLOL3D2D76KqOW0b6cgIF9bE6ca9QS931EnKOc4pS7wDZ0djKqu4rUPaupSLiRPt9IAIL7W8lpW8qOmCvoDEoDwNvVxzk7n6dp1Hm0hRcZyyxofI79gWOpj77UqGW3vgLA1vgbjNrY3e8R3lvPhuTbjVrc/lISOz+hPOn7zAkcuhFXs6uZdc51TPefTrQ9GgCHx8GKvhWc63suqd6pAHjwsKR3Cdk+2eT75BvLXN63nDB7GNP8phm1tc61dLu7mRUwy6htGNjAtoPbmBM4x6jVHqyleKCYWQGzCLGFANDh7mB1/2qm+U0jwWvob9Pv6WdZ3zIKfArI8sky5l/au5Qk7yQm+042au/2v4sdO9P9pxu19c71tLnauDbwWqNWNVjF5sHNXBd4nfGx2lGjRpGRkcGWLVs4cOAAAAEBAeTm5lJXV8eePXsAsNlsTJo0idbWVpqbm41l5uXl0dPTQ01NjVHLzMzE19eXiooKo5aUlERsbCwlJSVGLSYmhpSUFDZt2mS8iQkNDSUrK4vq6mocDgcAvr6+5Ofn09jYSHt7uzF/YWEh3/jNCs6PHd5u3my042uHmYnD28OaNju7+uDbh22zG/ba2LDXzs3pLnz+5yR6XbeNNW12rkpyEeU/VNvrhDcbvbhwtJu00KH1HPTAX3d4kR/h5pyo4XW/XGcn2h8uiR9ez7+a7fS7YHbycG19h41qh41bMoZrW/bb+LTDzg1jXQT7DNVaem2sbLYzY4ybhMCh9RwYhFfqvZgS4ybnsP3XX3bYWR89kcbIi4zahJaXGLQHUB13jVFL71hBUP8uNiXNM2oJnetJ2F9CacoduG1DK488UE3a7pVUxn+bXr8YAIKc7YxvfZma6MvZFzwOAC/3AIWNz9ISfi4to841lpm/cxHd/gnUxlxu1LLaXsPLPUBVwvD2kLLnfSIPVFOWcodRi3VsIHnfOjYmzmPAe+i1Iay3gcz2t9g2+hq6AhIB8Bt0kNf8Ag2RF9EROtGYf1L907Tv2sXOnTuNWm5uLgMDA1RXVw+PRXo6QUFBI552PWbMGOLj4ykpKcHjGRrfqKgoUlNTqaiooK+vD4Dg4GBycnLYsWMHnZ2dQ2Ph5UVhYSHNzc0jbgRYUFCAw+Ggrq7OqGVnZ2Oz2diyZcvwWKSkEBERQXl5uVEbPXo0SUlJbNiwgcHBQWDoQZjjxo1j69atdHd3A+Dv78/EiROpr69n9+7dxvyTJ0+mra2NpqamEWPhdDrZvn27UcvIyCAgIIDNmzcbtcTEROLi4kZ8BP/QWBzPJR42z6GRNMnAwAA7d+7E4XCwdOlS/t//+3+sXbv2qGHlaEdUEhMTcTgchIaGnvTeUh5856Qv80zU4P8ds1uwjNyxSWa3YBkVcyuOPdEZQNv5MG3rh5nvMLuDs1pXVxdhYWFf6PXb9CMqvr6+pKenA0PvbkpKSvjDH/7An//85yOm9fPzw8/P73S3KCIiIiax3H1U3G73iKMmIiIi8tVl6hGVhx56iJkzZ5KUlER3dzcvvfQSa9asYeXKlWa2JSIiIhZhalDp6Ojgu9/9Lm1tbYSFhTFx4kRWrlzJpZdeeuyZRURE5KxnalBZtGiRmasXERERi7PcNSoiIiIihyioiIiIiGUpqIiIiIhlKaiIiIiIZSmoiIiIiGUpqIiIiIhlKaiIiIiIZSmoiIiIiGUpqIiIiIhlKaiIiIiIZSmoiIiIiGUpqIiIiIhlKaiIiIiIZSmoiIiIiGUpqIiIiIhlKaiIiIiIZSmoiIiIiGUpqIiIiIhlKaiIiIhYSH9/P7Nnz2bcuHHk5eVx6aWXUlNTY3ZbplFQERERsZjbb7+d6upqNm3axNVXX81tt91mdkumUVARERGxEH9/f77xjW9gs9kAmDJlCg0NDeY2ZSIFFREREQv7wx/+wNVXX212G6bxNrsBERERObpf//rX1NTUsHr1arNbMY2CioiIiAX97ne/4/XXX2fVqlUEBgaa3Y5pFFREREQs5oknnuAf//gHq1atIjw83Ox2TKWgIiIiYiHNzc3cf//9pKamcvHFFwPg5+fHv//9b5M7M4eCioiIiIWMGTMGj8djdhuWoU/9iIiIiGUpqIiIiIhlKaiIiIiIZZkaVBYuXMikSZMICQkhJiaG2bNnU11dbWZLIiIiYiGmBpW1a9dy55138umnn/Lee+8xODjIZZddRk9Pj5ltiYiIiEWY+qmff/3rXyO+/8tf/kJMTAxlZWVMmzbNpK5ERETEKix1jYrD4QAgIiLC5E5ERETECixzHxW32829997L+eefz4QJE446jdPpxOl0Gt93dXWdrvZERETEBJYJKnfeeSeVlZV89NFHnznNwoULWbBgwRH10tJSgoODAcjPz6e7u5va2lrj51lZWXh5eVFVVWXUUlJSiIyMpKyszKjFxsaSnJzMxo0bGRgYYN44F809Nt5tsXP5GBfx//Oohe5BeLXei6kxbrLDh2/Ks3i7nexwD1NihmuvN9gJ8oYZY9xGbXWrnb39cEPqcK1sj41N++zckuHCPvRkb3Z02Vi3y841yS5G+Q3VOvrh7Z1eXBLvJiV4aD1ON/y9xovCKDd5EcPrfqnWTkIQXDh6eD3vNNlxe+DKpOHaR+026rtt3Jw+XKvotFGy286cNBfFvvcAEN5bx7j2t9kadx3d/gkA+A92MrH5ReqjLmF3yHDAnFz/FG2hBTRFfs2o5Ta/iNM7jO2jrzJqGe3LCRjYx+bEuUYtcd9HxDnKKU65C2xDB/2iuqtI3bOaioQb6fONBCC4v5WctqXsiLmCzqA0ALxdfZyz83maRp1HW3iRscyCxufYHziW+uhLjVp26ysAbI2/waiN3f0e4b31bEi+3ajF7S8lsfMTypO+z5zAoaN9za5m1jnXMd1/OtH2aAAcHgcr+lZwru+5pHqnAuDBw5LeJWT7ZJPvk28sc3nfcsLsYUzzGz7Fuda5lm53N7MCZhm1DQMb2HZwG3MC5xi12oO1FA8UMytgFiG2EAA63B2s7l/NNL9pJHgN/W36Pf0s61tGgU8BWT5ZxvxLe5eS5J3EZN/JRu3d/nexY2e6/3Sjtt65njZXG9cGXmvUqgar2Dy4mesCr6O4uBiAUaNGkZGRwZYtWzhw4AAAAQEB5ObmUldXx549ewCw2WxMmjSJ1tZWmpubjWXm5eXR09NDTU2NUcvMzMTX15eKigqjlpSURGxsLCUlJUYtJiaGlJQUNm3aZLyJCQ0NJSsri+rqauMora+vL/n5+TQ2NtLe3m7MX1hYSGaYm/Njh7ebNxvt+NphZuLw9rCmzc6uPvj2Ydvshr02Nuy1c3O6C5//OTZd121jTZudq5JcRPkP1fY64c1GLy4c7SYtdGg9Bz3w1x1e5Ee4OSdqeN0v19mJ9odL4ofX869mO/0umJ08XFvfYaPaYeOWjOHalv02Pu2wc8NYF8E+Q7WWXhsrm+3MGOMmIXBoPQcG4ZV6L6bEuMk5bP/1lx122kMn0hh5kVGb0PISg/YAquOuMWrpHSsI6t/FpqR5Ri2hcz0J+0soTbkDt21o5ZEHqknbvZLK+G/T6xcDQJCznfGtL1MTfTn7gscB4OUeoLDxWVrCz6Vl1LnGMvN3LqLbP4HamMuNWlbba3i5B6hKGN4eUva8T+SBaspS7jBqsY4NJO9bx8bEeQx4D702hPU2kNn+FttGX0NXQCIAfoMO8ppfoCHyIjpCJxrzT6p/mm/+/ToKfQuN2oq+FQTYA7jY72Kjts65jk53J1cFDO/TNg1uYsvgFr4V+C3s/3PSov5gPZ8OfMpM/5mE28MB2OPew3v973GB3wUkeg31M8AAr/W+xkSfiYz3GW8s8/Xe14nzimOq31Sjtqp/FW7cXOZ/mVErHihm58GdfDPwm0Zt2+A2Ngxu4JqAa/C3Df2jbHG18KHzQ77u/3Vi7EN/m25PN2/3vc1k38mkeacZ8/+j9x+8e9m7NDU1GbXc3FycTifbt283ahkZGQQEBLB582ajlpiYSFxcnLGvAIiKiiI1NXXE6/Gx2DwWuP3dXXfdxZtvvsmHH37I2LFjP3O6ox1RSUxMxOFwEBoaetL7SnnwnZO+zDNRg/93zG7BMnLHJpndgmVUzK049kRnAG3nw7StD9O2PuxUbOtdXV2EhYV9oddvU4+oeDwe7r77bpYtW8aaNWs+N6TA0LMO/Pz8TlN3IiIiYjZTg8qdd97JSy+9xJtvvklISAi7du0CICwsjICAADNbExEREQsw9VM/zzzzDA6Hg4suuoi4uDjj6+WXXzazLREREbEI00/9iIiIiHwWS91HRURERORwCioiIiJiWQoqIiIiYlkKKiIiImJZCioiIiJiWQoqIiIiYlkKKiIiImJZCioiIiJiWQoqIiIiYlkKKiIiImJZCioiIiJiWQoqIiIiYlkKKiIiImJZCioiIiJiWQoqIiIiYlkKKiIiImJZCioiIiJiWQoqIiIiYlkKKiIiImJZCioiIiJiWQoqIiIiYlkKKiIiImJZCioiIiJiWQoqIiIiYlkKKiIiImJZCioiIiJiWQoqIiIiYlkKKiIiImJZCioiIiJiWQoqIiIiYlkKKiIiImJZpgaVDz/8kCuvvJL4+HhsNhtvvPGGme2IiIiIxZgaVHp6esjLy+NPf/qTmW2IiIiIRXmbufKZM2cyc+ZMM1sQERERCzM1qBwvp9OJ0+k0vu/q6jKxGxERETnVzqigsnDhQhYsWHBEvbS0lODgYADy8/Pp7u6mtrbW+HlWVhZeXl5UVVUZtZSUFCIjIykrKzNqsbGxJCcns3HjRgYGBpg3zkVzj413W+xcPsZFfODQdN2D8Gq9F1Nj3GSHe4z5F2+3kx3uYUrMcO31BjtB3jBjjNuorW61s7cfbkgdrpXtsbFpn51bMlzYbUO1HV021u2yc02yi1F+Q7WOfnh7pxeXxLtJCR5aj9MNf6/xojDKTV7E8LpfqrWTEAQXjh5ezztNdtweuDJpuPZRu436bhs3pw/XKjptlOy2MyfNRbHvPQCE99Yxrv1ttsZdR7d/AgD+g51MbH6R+qhL2B0ywZh/cv1TtIUW0BT5NaOW2/wiTu8wto++yqhltC8nYGAfmxPnGrXEfR8R5yinOOUusA2dnYzqriJ1z2oqEm6kzzcSgOD+VnLalrIj5go6g9IA8Hb1cc7O52kadR5t4UXGMgsan2N/4Fjqoy81atmtrwCwNf4GozZ293uE99azIfl2oxa3v5TEzk8oT/o+cwIjAGh2NbPOuY7p/tOJtkcD4PA4WNG3gnN9zyXVOxUADx6W9C4h2yebfJ98Y5nL+5YTZg9jmt80o7bWuZZudzezAmYZtQ0DG9h2cBtzAucYtdqDtRQPFDMrYBYhthAAOtwdrO5fzTS/aSR4Df1t+j39LOtbRoFPAVk+Wcb8S3uXkuSdxGTfyUbt3f53sWNnuv90o7beuZ42VxvXBl5r1KoGq9g8uJnrAq+juLgYgFGjRpGRkcGWLVs4cOAAAAEBAeTm5lJXV8eePXsAsNlsTJo0idbWVpqbm41l5uXl0dPTQ01NjVHLzMzE19eXiooKo5aUlERsbCwlJSVGLSYmhpSUFDZt2mS8iQkNDSUrK4vq6mocDgcAvr6+5Ofn09jYSHt7uzF/YWEhmWFuzo8d3m7ebLTja4eZicPbw5o2O7v64NuHbbMb9trYsNfOzekufP7nJHpdt401bXauSnIR5T9U2+uENxu9uHC0m7TQofUc9MBfd3iRH+HmnKjhdb9cZyfaHy6JH17Pv5rt9LtgdvJwbX2HjWqHjVsyhmtb9tv4tMPODWNdBPsM1Vp6baxstjNjjJuEwKH1HBiEV+q9mBLjJuew/ddfdthpD51IY+RFRm1Cy0sM2gOojrvGqKV3rCCofxebkuYZtYTO9STsL6E05Q7ctqGVRx6oJm33Sirjv02vXwwAQc52xre+TE305ewLHgeAl3uAwsZnaQk/l5ZR5xrLzN+5iG7/BGpjLjdqWW2v4eUeoCpheHtI2fM+kQeqKUu5w6jFOjaQvG8dGxPnMeA99NoQ1ttAZvtbbBt9DV0BiQD4DTrIa36BhsiL6AidaMw/qf5pxnmPo9C30Kit6FtBgD2Ai/0uNmrrnOvodHdyVcDwPm3T4Ca2DG7hW4Hfwv4/V1fUH6zn04FPmek/k3B7OAB73Ht4r/89LvC7gESvoX4GGOC13teY6DOR8T7jjWW+3vs6cV5xTPWbatRW9a/CjZvL/C8zasUDxew8uJNvBn7TqG0b3MaGwQ1cE3AN/rahf5QtrhY+dH7I1/2/Tox96G/T7enm7b63mew7mTTvNGP+f/T+g7a2Npqamoxabm4uTqeT7du3G7WMjAwCAgLYvHmzUUtMTCQuLs7YVwBERUWRmpo64vX4WGwej8dz7MlOPZvNxrJly5g9e/ZnTnO0IyqJiYk4HA5CQ0NPek8pD75z0pd5Jmrw/47ZLVhG7tgks1uwjIq5Fcee6Ayg7XyYtvVh2taHnYptvauri7CwsC/0+n1GHVHx8/PDz8/P7DZERETkNNF9VERERMSyTD2icuDAgRHnpevr69m4cSMREREkJemwm4iIyFedqUGltLSUiy8evjDpvvvuA2Du3Ln85S9/MakrERERsQpTg8pFF12ERa7lFREREQvSNSoiIiJiWQoqIiIiYlkKKiIiImJZCioiIiJiWQoqIiIiYlkKKiIiImJZCioiIiJiWQoqIiIiYlkKKiIiImJZCioiIiJiWQoqIiIiYlkKKiIiImJZCioiIiJiWQoqIiIiYlkKKiIiImJZCioiIiJiWQoqIiIiYlkKKiIiImJZCioiIiJiWQoqIiIiYlkKKiIiImJZCioiIiJiWQoqIiIiYlkKKiIiImJZCioiIiJiWQoqIiIiYlkKKiIiImJZCioiIiJiWQoqIiIiYlkKKiIiImJZlggqf/rTn0hJScHf359zzz2X4uJis1sSERERCzA9qLz88svcd999PPLII5SXl5OXl8eMGTPo6OgwuzURERExmelB5YknnuD73/8+3/ve98jJyeHZZ58lMDCQ//7v/za7NRERETGZt5krHxgYoKysjIceesio2e12pk+fzvr164+Y3ul04nQ6je8dDgcAXV1dp6Q/t7P3lCz3TNNl85jdgmW4+lxmt2AZp2q7O920nQ/Ttj5M2/qwU7GtH1qmx3Psf3OmBpU9e/bgcrmIjY0dUY+NjWXbtm1HTL9w4UIWLFhwRD0xMfGU9SgQZnYDlrLV7AYsI+wO/cs42+gvejht64ecym29u7ubsLDPX76pQeV4PfTQQ9x3333G9263m3379hEZGYnNZjOxs1Ojq6uLxMREmpqaCA0NNbsdETlFtK3LV43H46G7u5v4+PhjTmtqUImKisLLy4v29vYR9fb2dkaPHn3E9H5+fvj5+Y2ohYeHn8oWLSE0NFQ7L5GvAG3r8lVyrCMph5h6Ma2vry+FhYWsXr3aqLndblavXs3UqVNN7ExERESswPRTP/fddx9z586lqKiIyZMn8+STT9LT08P3vvc9s1sTERERk5keVL71rW+xe/du/uu//otdu3aRn5/Pv/71ryMusP0q8vPz45FHHjnidJeInF20rYt8Npvni3w2SERERMQEpt/wTUREROSzKKiIiIiIZSmoiIiIiGUpqIiIiIhlKaiIiIiIZSmoiIhYjMulB+KJHKKPJ58BamtrWbp0KYODg6SkpHDTTTeZ3ZKInAJ79uwhKioKGAorXl5eJnckYj4dUbG4yspKCgsL+ec//8lbb73FbbfdxqxZs/j3v/9tdmsichJt3bqVxMREbrvtNgC8vLx0ZEUEHVGxtL6+Pq655hrS0tL405/+RH9/P/X19Vx11VXEx8czf/58Lr74YrPbFJEvqaWlhWuvvZaDBw+ya9cuZs2axZ///GdAR1ZEdETFwgICAjhw4AApKSkAeHt7k52dzdq1a9m/fz8LFiygubnZ3CZF5EvxeDysXLmSMWPG8Pjjj/OrX/2KN998kx/84AfA0JGVgwcPmtyliHlMf9aPHJ3H48HpdOJ0OqmrqwOGgsrAwADx8fGsXLmS8ePH89hjj/H000+b3K2InCibzcZVV11FWFgYF110Ef39/Xg8Hh566CE8Hg/PPfcc3t7eOrIiX1k6omJh/v7+PPTQQyxevJgXX3wRAF9fX/r7+xk9ejRPPvkkb7/9Njt37kRn8ETOTB6Ph6ioKK677jpgaLu//vrrefTRR3nrrbe4/fbbgaEjK3/729/YuXOnme2KnHY6omIhh94xud1u7PahDHnRRRfxgx/8gPnz5+Pt7c2cOXPw9/cHIDg4GF9fX4KCgrDZbGa2LiLH4Wjb+uGCg4ON4PLggw9is9kIDg7m97//PQ0NDae5WxFz6YiKRVRWVjJ9+nSampqw2+243W4AIiIiuP3225k+fTr33XcfTz/9NP39/fT09FBaWkpwcPBRd3QiYk2fta3/byEhIXzzm9/k17/+Nc8//zx/+ctfKCkpISkp6TR3LGIuferHAhoaGrj00kupra0lPT2d999/nzFjxnDw4EG8vYcOetXU1PDyyy/zi1/8gsTERIKCgmhtbWXlypUUFBSY/BuIyBfxWdv6Zx1ZAZg3bx6vvvoq//73v8nJyTnNHYuYT2/FTdbf38+iRYvIzc1l1apVxMXFccEFF9Dc3Iy3t7dxtX96ejoPP/wwGzdu5KGHHuKhhx6iuLhYIUXkDPF52/pnHVlZtmwZ77//PmvWrFFIka8sHVGxgH/84x/Y7Xa+9a1v0djYyM0338zOnTv56KOPGDNmzDHPZ4vImeFY2/r/3sb37t1Lf38/CQkJJnYtYi4FFZO43W5cLhc+Pj4j6h6Ph/r6er73ve/R2NjIxx9/TEJCAv39/WzdupXMzEwCAwNN6lpEjtfxbutOp5MtW7aQkZFBcHCwSV2LWIeCigm2bNnCr3/9a3bt2kV6ejpXXnklV1xxBTC087LZbNTW1jJv3jwaGxv54IMPePzxx/n3v//Ne++9R3h4uLm/gIh8IdrWRb48BZXTrLq6mnPPPZeZM2eSkpLCP//5T3x8fLjgggv4/e9/DwzvwOrq6rj11ltZu3YtgYGBfPDBB0yaNMnk30BEvght6yInhy54OI08Hg9//etfmTFjBv/4xz9YuHAh69atY/bs2axZs8a4sdOhe6KMGTOG0aNHM2rUKIqLi7XjEjlDaFsXOXkUVE4jm81Ga2sru3btMmohISHcc8893HTTTWzYsIHHHnsMGNrR/fnPf+bVV19l1apVuuJf5AyibV3k5FFQOU0OnWE755xzcLlcVFdXGz8LCQlh3rx5FBQU8NZbb3HgwAFsNhspKSls3bpVH0EWOYNoWxc5uXSNymlWW1vLlClTuOqqq/jDH/5AcHCwcZ66qamJ5ORk3nnnHWbOnGl2qyLyJWhbFzk59Kyf0ywtLY1XXnmFmTNnEhAQwPz584mKigLAx8eHiRMn6kp/kbOAtnWRk0NBxQQXX3wxr776Ktdffz1tbW3ccMMNTJw4kb/+9a90dHSQmJhodosichJoWxf58nTqx0Tl5eXcd999NDQ04O3tjZeXF0uWLNF5apGzjLZ1kROnoGKyrq4u9u3bR3d3N3FxccahYRE5u2hbFzkxCioiIiJiWfp4soiIiFiWgoqIiIhYloKKiIiIWJaCioiIiFiWgoqIiIhYloKKiIiIWJaCioiIiFiWgoqIiIhYloKKiIiIWJaCioiIiFiWgoqIiIhYloKKiIiIWNb/DzW0O3q2DkbfAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_histogram(counts)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
- Currently shipping new qBraid-SDK environment that includes all of these updated dependencies. For anyone that still has the old qBraid-SDK environment, they will just need to uninstall and re-install it to get the latest version.
- The qBraid-CLI has also been updated, so the "enable jobs" commands from before are now deprecated. This updated SDK environment comes pre-configured with quantum jobs enabled for Amazon Braket, so that step shouldn't be necessary anymore anyways.
- qBraid does not support managed quantum jobs through IBM anymore, so the Aer simulations will work, but the IBM backend jobs will only go through if you have your own credentials configured.
- Please let me know if you have questions about any of these updates

If you would prefer the cells not be executed, feel free to clear the outputs and re-push.